### PR TITLE
feat: automate package builds via script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "scripts": {
-    "dev": "pnpm -F @noxigui/parser build && pnpm -F @noxigui/runtime build && pnpm -F @noxigui/renderer-pixi build && pnpm -F @noxigui/playground dev",
-    "build": "pnpm -F @noxigui/parser build && pnpm -F @noxigui/runtime build && pnpm -F @noxigui/renderer-pixi build && pnpm -F @noxigui/playground build"
+    "dev": "node scripts/build-packages.js && pnpm -F @noxigui/playground dev",
+    "build": "node scripts/build-packages.js && pnpm -F @noxigui/playground build"
   }
 }

--- a/scripts/build-packages.js
+++ b/scripts/build-packages.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const packagesDir = path.join(__dirname, '..', 'packages');
+const packageDirs = fs
+  .readdirSync(packagesDir)
+  .filter((name) => fs.statSync(path.join(packagesDir, name)).isDirectory());
+
+const packages = packageDirs
+  .map((dir) => {
+    const pkgJsonPath = path.join(packagesDir, dir, 'package.json');
+    const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+    return {
+      name: pkgJson.name,
+      deps: Object.assign({}, pkgJson.dependencies, pkgJson.devDependencies),
+    };
+  })
+  .filter((pkg) => pkg.name !== '@noxigui/playground');
+
+// Build dependency graph and perform topological sort
+const graph = new Map();
+for (const pkg of packages) {
+  const deps = Object.keys(pkg.deps || {}).filter((dep) => dep.startsWith('@noxigui/'));
+  graph.set(pkg.name, deps);
+}
+
+const visited = new Set();
+const order = [];
+function visit(name, stack = new Set()) {
+  if (visited.has(name)) return;
+  if (stack.has(name)) throw new Error('Circular dependency detected');
+  stack.add(name);
+  const deps = graph.get(name) || [];
+  for (const dep of deps) {
+    if (graph.has(dep)) visit(dep, stack);
+  }
+  stack.delete(name);
+  visited.add(name);
+  order.push(name);
+}
+
+for (const name of graph.keys()) {
+  visit(name);
+}
+
+for (const name of order) {
+  console.log(`Building ${name}...`);
+  execSync(`pnpm -F ${name} build`, { stdio: 'inherit' });
+}


### PR DESCRIPTION
## Summary
- add Node script to traverse packages directory and build each package
- update root dev/build commands to use the new script

## Testing
- `node scripts/build-packages.js` (fails: Cannot find module '@noxigui/runtime')
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68b0c837e590832a8aee2dea371124a8