### PR TITLE
feat(core): add aspect ratio and snap rules

### DIFF
--- a/packages/core/src/layout/rules/extra.ts
+++ b/packages/core/src/layout/rules/extra.ts
@@ -1,20 +1,33 @@
 import type { SizeRule } from '../engine.js';
 
-// Placeholder aspect ratio rule. In a full implementation this would compute a
-// missing intrinsic dimension from its paired axis.
+/**
+ * Compute a missing dimension using an aspect ratio. The ratio is provided via
+ * `style.value` and represents the width/height relationship. When measuring
+ * the `x` axis the size is `pairedIntrinsic * ratio`. For the `y` axis the size
+ * becomes `pairedIntrinsic / ratio`.
+ */
 export const AspectRatioRule: SizeRule = {
   id: 'aspect',
   phase: 'primary',
   priority: 40,
-  applies: () => false,
-  compute: () => null,
+  applies: ctx =>
+    (ctx.style.unit === 'auto' || ctx.style.unit === 'content') &&
+    typeof ctx.style.value === 'number' &&
+    ctx.style.value > 0 &&
+    typeof ctx.pairedIntrinsic === 'number',
+  compute: ctx => {
+    const ratio = ctx.style.value!;
+    const paired = ctx.pairedIntrinsic!;
+    const size = ctx.axis === 'x' ? paired * ratio : paired / ratio;
+    return { size, final: true };
+  },
 };
 
-// Snap rule is optional – here it simply rounds the current size.
+// Snap rule – rounds the current size to the nearest integer.
 export const SnapRule: SizeRule = {
   id: 'snap',
   phase: 'post',
   priority: 10,
-  applies: () => false,
-  compute: () => null,
+  applies: () => true,
+  compute: ctx => ({ size: Math.round(ctx.current ?? 0), final: true }),
 };

--- a/packages/core/tests/layout/extra.test.ts
+++ b/packages/core/tests/layout/extra.test.ts
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { RuleRegistry, FixedPxRule, AspectRatioRule, SnapRule } from '../../src/index.js';
+import type { AxisBox, MeasureCtx } from '../../src/index.js';
+
+const box: AxisBox = {
+  marginStart: 0, marginEnd: 0,
+  borderStart: 0, borderEnd: 0,
+  paddingStart: 0, paddingEnd: 0,
+};
+
+test('aspect ratio width from height', () => {
+  const reg = new RuleRegistry([AspectRatioRule]);
+  const ctx: MeasureCtx = {
+    axis: 'x',
+    box,
+    style: { unit: 'auto', value: 2 },
+    constraints: { available: 0 },
+    pairedIntrinsic: 50,
+  };
+  const size = reg.run({ ...ctx });
+  assert.equal(size, 100);
+});
+
+test('aspect ratio height from width', () => {
+  const reg = new RuleRegistry([AspectRatioRule]);
+  const ctx: MeasureCtx = {
+    axis: 'y',
+    box,
+    style: { unit: 'auto', value: 2 },
+    constraints: { available: 0 },
+    pairedIntrinsic: 100,
+  };
+  const size = reg.run({ ...ctx });
+  assert.equal(size, 50);
+});
+
+test('snap rounds to nearest integer', () => {
+  const reg = new RuleRegistry([FixedPxRule, SnapRule]);
+  const ctx: MeasureCtx = {
+    axis: 'x',
+    box,
+    style: { unit: 'px', value: 3.6 },
+    constraints: { available: 0 },
+  };
+  const size = reg.run({ ...ctx });
+  assert.equal(size, 4);
+});


### PR DESCRIPTION
## Summary
- implement `AspectRatioRule` and `SnapRule`
- add tests for aspect ratio and snap behaviour

## Testing
- `pnpm --filter=@noxigui/core test`


------
https://chatgpt.com/codex/tasks/task_e_68b0d142a930832ab8652a2f7701f00a