### PR TITLE
refactor(runtime): integrate core sizing rules

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "pixi.js": "^7.4.3",
-    "@noxigui/parser": "file:../parser"
+    "@noxigui/parser": "file:../parser",
+    "@noxigui/core": "file:../core"
   },
   "devDependencies": {
     "typescript": "~5.8.3"

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -1,35 +1,73 @@
-// Core UI primitives
+// Runtime base UIElement built on core RuleRegistry
+
+import type { MeasureCtx } from '../../core/src/index.js';
+import { createDefaultRegistry, RuleRegistry } from '../../core/src/index.js';
 
 export type Size = { width: number; height: number };
 export type Rect = { x: number; y: number; width: number; height: number };
 
+const defaultRegistry = createDefaultRegistry();
+
+/**
+ * Basic UI element supporting margin and preferred/min sizes. The size
+ * computation is delegated to the core RuleRegistry to avoid duplicating
+ * clamp logic across runtime elements.
+ */
 export abstract class UIElement {
   desired: Size = { width: 0, height: 0 };
   final: Rect = { x: 0, y: 0, width: 0, height: 0 };
+
   margin = { l: 0, t: 0, r: 0, b: 0 };
-  minW = 0; minH = 0; // MinWidth/MinHeight
-  prefW?: number; prefH?: number; // Width/Height (desired size)
+  minW = 0; minH = 0;
+  prefW?: number; prefH?: number;
+
+  protected registry: RuleRegistry = defaultRegistry;
+
+  protected measureAxis(axis: 'x' | 'y', avail: number, intrinsic: number): number {
+    const pref = axis === 'x' ? this.prefW : this.prefH;
+    const marginSum = axis === 'x' ? this.margin.l + this.margin.r : this.margin.t + this.margin.b;
+    const min = (axis === 'x' ? this.minW : this.minH) + marginSum;
+    const prefVal = pref !== undefined ? pref + marginSum : undefined;
+    const style = prefVal !== undefined ? { unit: 'px', value: prefVal } as const : { unit: 'auto' } as const;
+    const ctx: MeasureCtx = {
+      axis,
+      box: { marginStart: 0, marginEnd: 0, borderStart: 0, borderEnd: 0, paddingStart: 0, paddingEnd: 0 },
+      style,
+      constraints: { available: avail, min },
+      intrinsic,
+    };
+    return this.registry.run(ctx);
+  }
 
   abstract measure(avail: Size): void;
   abstract arrange(rect: Rect): void;
 }
 
+/**
+ * Simple presenter that proxies measurement and arrangement to a single child.
+ */
 export class ContentPresenter extends UIElement {
   child?: UIElement;
+
   measure(avail: Size) {
     if (this.child) {
       this.child.measure(avail);
+      const intrinsicW = this.child.desired.width + this.margin.l + this.margin.r;
+      const intrinsicH = this.child.desired.height + this.margin.t + this.margin.b;
       this.desired = {
-        width: this.child.desired.width + this.margin.l + this.margin.r,
-        height: this.child.desired.height + this.margin.t + this.margin.b,
+        width: this.measureAxis('x', avail.width, intrinsicW),
+        height: this.measureAxis('y', avail.height, intrinsicH),
       };
     } else {
+      const intrinsicW = this.margin.l + this.margin.r;
+      const intrinsicH = this.margin.t + this.margin.b;
       this.desired = {
-        width: this.margin.l + this.margin.r,
-        height: this.margin.t + this.margin.b,
+        width: this.measureAxis('x', avail.width, intrinsicW),
+        height: this.measureAxis('y', avail.height, intrinsicH),
       };
     }
   }
+
   arrange(rect: Rect) {
     const x = rect.x + this.margin.l, y = rect.y + this.margin.t;
     const w = Math.max(0, rect.width - this.margin.l - this.margin.r);
@@ -38,3 +76,4 @@ export class ContentPresenter extends UIElement {
     if (this.child) this.child.arrange({ x, y, width: w, height: h });
   }
 }
+

--- a/packages/runtime/src/elements/BorderPanel.ts
+++ b/packages/runtime/src/elements/BorderPanel.ts
@@ -27,25 +27,17 @@ export class BorderPanel extends UIElement {
       width: Math.max(0, avail.width - this.margin.l - this.margin.r - this.padding.l - this.padding.r),
       height: Math.max(0, avail.height - this.margin.t - this.margin.b - this.padding.t - this.padding.b),
     };
+    let intrinsicW = this.margin.l + this.margin.r + this.padding.l + this.padding.r;
+    let intrinsicH = this.margin.t + this.margin.b + this.padding.t + this.padding.b;
     if (this.child) {
       this.child.measure(inner);
-      this.desired = {
-        width: this.child.desired.width + this.margin.l + this.margin.r + this.padding.l + this.padding.r,
-        height: this.child.desired.height + this.margin.t + this.margin.b + this.padding.t + this.padding.b,
-      };
-    } else {
-      this.desired = {
-        width: this.margin.l + this.margin.r + this.padding.l + this.padding.r,
-        height: this.margin.t + this.margin.b + this.padding.t + this.padding.b,
-      };
+      intrinsicW += this.child.desired.width;
+      intrinsicH += this.child.desired.height;
     }
-
-    this.desired.width = Math.max(this.desired.width, this.minW + this.margin.l + this.margin.r);
-    this.desired.height = Math.max(this.desired.height, this.minH + this.margin.t + this.margin.b);
-    if (this.prefW !== undefined)
-      this.desired.width = Math.max(this.desired.width, this.prefW + this.margin.l + this.margin.r);
-    if (this.prefH !== undefined)
-      this.desired.height = Math.max(this.desired.height, this.prefH + this.margin.t + this.margin.b);
+    this.desired = {
+      width: this.measureAxis('x', avail.width, intrinsicW),
+      height: this.measureAxis('y', avail.height, intrinsicH),
+    };
   }
 
   arrange(rect: Rect) {

--- a/packages/runtime/src/elements/Grid.ts
+++ b/packages/runtime/src/elements/Grid.ts
@@ -147,9 +147,11 @@ export class Grid extends UIElement {
     const widthSum = this.cols.reduce((s, c) => s + c.actual, 0) + totalColGaps;
     const heightSum = this.rows.reduce((s, r) => s + r.actual, 0) + totalRowGaps;
 
+    const intrinsicW = widthSum + this.margin.l + this.margin.r;
+    const intrinsicH = heightSum + this.margin.t + this.margin.b;
     this.desired = {
-      width: widthSum + this.margin.l + this.margin.r,
-      height: heightSum + this.margin.t + this.margin.b,
+      width: this.measureAxis('x', avail.width, intrinsicW),
+      height: this.measureAxis('y', avail.height, intrinsicH),
     };
   }
 

--- a/packages/runtime/src/elements/Image.ts
+++ b/packages/runtime/src/elements/Image.ts
@@ -36,21 +36,33 @@ export class Image extends UIElement {
     const baseH = natH > 0 ? natH : fallback;
 
     if (this.prefW !== undefined && this.prefH !== undefined) {
+      const intrinsicW = this.prefW + this.margin.l + this.margin.r;
+      const intrinsicH = this.prefH + this.margin.t + this.margin.b;
       this.desired = {
-        width: this.prefW + this.margin.l + this.margin.r,
-        height: this.prefH + this.margin.t + this.margin.b
+        width: this.measureAxis('x', avail.width, intrinsicW),
+        height: this.measureAxis('y', avail.height, intrinsicH)
       };
       return;
     }
 
     if (this.prefW !== undefined && this.prefH === undefined) {
       const h = baseH * (this.prefW / baseW);
-      this.desired = { width: this.prefW + this.margin.l + this.margin.r, height: h + this.margin.t + this.margin.b };
+      const intrinsicW = this.prefW + this.margin.l + this.margin.r;
+      const intrinsicH = h + this.margin.t + this.margin.b;
+      this.desired = {
+        width: this.measureAxis('x', avail.width, intrinsicW),
+        height: this.measureAxis('y', avail.height, intrinsicH)
+      };
       return;
     }
     if (this.prefH !== undefined && this.prefW === undefined) {
       const w = baseW * (this.prefH / baseH);
-      this.desired = { width: w + this.margin.l + this.margin.r, height: this.prefH + this.margin.t + this.margin.b };
+      const intrinsicW = w + this.margin.l + this.margin.r;
+      const intrinsicH = this.prefH + this.margin.t + this.margin.b;
+      this.desired = {
+        width: this.measureAxis('x', avail.width, intrinsicW),
+        height: this.measureAxis('y', avail.height, intrinsicH)
+      };
       return;
     }
 
@@ -92,10 +104,12 @@ export class Image extends UIElement {
       }
     }
 
-    drawW = Math.max(drawW, this.minW);
-    drawH = Math.max(drawH, this.minH);
-
-    this.desired = { width: drawW + this.margin.l + this.margin.r, height: drawH + this.margin.t + this.margin.b };
+    const intrinsicW = drawW + this.margin.l + this.margin.r;
+    const intrinsicH = drawH + this.margin.t + this.margin.b;
+    this.desired = {
+      width: this.measureAxis('x', avail.width, intrinsicW),
+      height: this.measureAxis('y', avail.height, intrinsicH)
+    };
   }
 
   arrange(rect: Rect) {

--- a/packages/runtime/src/elements/Text.ts
+++ b/packages/runtime/src/elements/Text.ts
@@ -15,16 +15,12 @@ export class Text extends UIElement {
   measure(avail: Size) {
     this.text.setWordWrap(Math.max(1, avail.width), 'left');
     const b = this.text.getBounds();
-    const w = b.width;
-    const h = b.height;
-    this.desired = { width: w + this.margin.l + this.margin.r, height: h + this.margin.t + this.margin.b };
-
-    this.desired.width = Math.max(this.desired.width, this.minW + this.margin.l + this.margin.r);
-    this.desired.height = Math.max(this.desired.height, this.minH + this.margin.t + this.margin.b);
-    if (this.prefW !== undefined)
-      this.desired.width = Math.max(this.desired.width, this.prefW + this.margin.l + this.margin.r);
-    if (this.prefH !== undefined)
-      this.desired.height = Math.max(this.desired.height, this.prefH + this.margin.t + this.margin.b);
+    const intrinsicW = b.width + this.margin.l + this.margin.r;
+    const intrinsicH = b.height + this.margin.t + this.margin.b;
+    this.desired = {
+      width: this.measureAxis('x', avail.width, intrinsicW),
+      height: this.measureAxis('y', avail.height, intrinsicH)
+    };
   }
 
   arrange(rect: Rect) {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,5 +1,6 @@
 export * from './template.js';
 export * from './core.js';
+export { createDefaultRegistry, RuleRegistry } from '../../core/src/index.js';
 export * from './elements/BorderPanel.js';
 export * from './elements/Image.js';
 export * from './elements/Text.js';

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -5,7 +5,13 @@
     "declaration": true,
     "declarationMap": true,
     "allowImportingTsExtensions": false,
-    "erasableSyntaxOnly": false
+    "erasableSyntaxOnly": false,
+    "baseUrl": "src",
+    "paths": {
+      "@noxigui/core": ["../core/src/index.ts"],
+      "@noxigui/core/*": ["../core/src/*"]
+    },
+    "moduleResolution": "node"
   },
   "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
 
   packages/runtime:
     dependencies:
+      '@noxigui/core':
+        specifier: file:../core
+        version: link:../core
       '@noxigui/parser':
         specifier: file:../parser
         version: link:../parser


### PR DESCRIPTION
## Summary
- base `UIElement` now sizes via core `RuleRegistry`
- migrate BorderPanel, Grid, Image and Text to shared sizing helper
- expose core registry utilities from runtime entry point

## Testing
- `pnpm -F @noxigui/runtime build`
- `pnpm -F @noxigui/core test`


------
https://chatgpt.com/codex/tasks/task_e_68b0d1490bf0832a815823f420958e50