### PR TITLE
refactor grid debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ This repository is a monorepo containing:
 - `@noxigui/playground` – a Vite playground for experimenting with the runtime.
 
 Run `pnpm dev` to start the playground or `pnpm build` to build all packages.
+
+## Debugging Grid Layouts
+
+The runtime can render grid layout diagnostics without bundling PIXI by
+default. Calling `await setGridDebug(true)` on a runtime instance lazily loads
+the debug renderer and overlays track, gap, margin and padding visuals on top
+of grids. Disable it with `setGridDebug(false)`.

--- a/packages/parser/src/parsers/GridParser.ts
+++ b/packages/parser/src/parsers/GridParser.ts
@@ -38,11 +38,6 @@ export class GridParser implements ElementParser {
   collect(into: PIXI.Container, el: UIElement, collect: (into: PIXI.Container, el: UIElement) => void) {
     if (el instanceof Grid) {
       for (const ch of el.children) collect(into, ch);
-      el.debugG.zIndex = 100000;
-      if (el.debugG.parent !== into) {
-        el.debugG.parent?.removeChild(el.debugG);
-        into.addChild(el.debugG);
-      }
       return true;
     }
     return false;

--- a/packages/parser/src/parsers/GridParser.ts
+++ b/packages/parser/src/parsers/GridParser.ts
@@ -13,7 +13,6 @@ export class GridParser implements ElementParser {
     const rgAttr = node.getAttribute('RowGap'); if (rgAttr != null) g.rowGap = parseFloat(rgAttr) || 0;
     const cgAttr = node.getAttribute('ColumnGap'); if (cgAttr != null) g.colGap = parseFloat(cgAttr) || 0;
     applyMargin(node, g);
-    const dbg = node.getAttribute('Debug'); if (dbg && dbg.toLowerCase() === 'true') g.debug = true;
     applyGridAttachedProps(node, g);
 
     for (const ch of Array.from(node.children)) {

--- a/packages/renderer-pixi/src/index.ts
+++ b/packages/renderer-pixi/src/index.ts
@@ -71,12 +71,24 @@ class PixiRenderGraphics implements RenderGraphics {
   clear() {
     this.g.clear();
   }
-  beginFill(color: number) {
-    this.g.beginFill(color);
+  beginFill(color: number, alpha = 1) {
+    this.g.beginFill(color, alpha);
     return this;
   }
   drawRect(x: number, y: number, w: number, h: number) {
     this.g.drawRect(x, y, w, h);
+    return this;
+  }
+  lineStyle(opts: { width: number; color: number; alpha?: number }) {
+    this.g.lineStyle({ width: opts.width, color: opts.color, alpha: opts.alpha ?? 1, alignment: 0 });
+    return this;
+  }
+  moveTo(x: number, y: number) {
+    this.g.moveTo(x, y);
+    return this;
+  }
+  lineTo(x: number, y: number) {
+    this.g.lineTo(x, y);
     return this;
   }
   endFill() {
@@ -84,6 +96,9 @@ class PixiRenderGraphics implements RenderGraphics {
   }
   destroy() {
     this.g.destroy();
+  }
+  setVisible(v: boolean) {
+    this.g.visible = v;
   }
   getDisplayObject() {
     return this.g;

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -9,7 +9,6 @@
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "pixi.js": "^7.4.3",
     "@noxigui/parser": "file:../parser"
   },
   "devDependencies": {

--- a/packages/runtime/src/elements/Grid.ts
+++ b/packages/runtime/src/elements/Grid.ts
@@ -1,8 +1,7 @@
-import * as PIXI from 'pixi.js';
 import { UIElement } from '../core.js';
 import type { Size, Rect } from '../core.js';
 import type { Len } from '../helpers.js';
-import { BorderPanel } from './BorderPanel.js';
+import type { GridDebugLayer } from './GridDebug.js';
 
 export class Row { actual = 0; desired = 0; constructor(public len: Len) {} }
 export class Col { actual = 0; desired = 0; constructor(public len: Len) {} }
@@ -20,13 +19,17 @@ export class Grid extends UIElement {
   colGap = 0;
 
   debug = false;
-  debugG = new PIXI.Graphics();
+  debugLayer?: GridDebugLayer;
 
   add(ch: UIElement) { this.children.push(ch); }
   static setRow(el: UIElement, i: number) { rowMap.set(el, i|0); }
   static setCol(el: UIElement, i: number) { colMap.set(el, i|0); }
   static setRowSpan(el: UIElement, n: number) { rowSpan.set(el, Math.max(1, n|0)); }
   static setColSpan(el: UIElement, n: number) { colSpan.set(el, Math.max(1, n|0)); }
+  static getRow(el: UIElement) { return rowMap.get(el); }
+  static getCol(el: UIElement) { return colMap.get(el); }
+  static getRowSpan(el: UIElement) { return rowSpan.get(el); }
+  static getColSpan(el: UIElement) { return colSpan.get(el); }
 
   measure(avail: Size) {
     if (this.rows.length === 0) this.rows.push(new Row({ kind: 'star', v: 1 }));
@@ -187,123 +190,6 @@ export class Grid extends UIElement {
       ch.arrange({ x, y, width: w, height: h });
     }
 
-    this.drawDebug(xs, ys);
-  }
-
-  private drawDebug(xs: number[], ys: number[]) {
-    const g = this.debugG;
-    g.visible = this.debug;
-    g.clear();
-    if (!this.debug) return;
-    if (this.final.width <= 0 || this.final.height <= 0) return;
-
-    const x0 = this.final.x, y0 = this.final.y;
-    const w0 = this.final.width, h0 = this.final.height;
-
-    const STROKE = 0x00ffff;
-    const STROKE_ALPHA = 0.7;
-    const GRID_LINE_ALPHA = 0.45;
-    const GAP_FILL = 0xff00ff;
-    const GAP_ALPHA = 0.10;
-    const MARGIN_FILL = 0xff9900;
-    const MARGIN_ALPHA = 0.22;
-    const PADDING_FILL = 0x66ccff;
-    const PADDING_ALPHA = 0.18;
-
-    g.lineStyle({ width: 2, color: STROKE, alpha: STROKE_ALPHA, alignment: 0 });
-    g.drawRect(x0, y0, w0, h0);
-
-    const colorForCol = (c: Col) =>
-      c.len.kind === 'px' ? 0x3da5ff : c.len.kind === 'auto' ? 0x5fff7a : 0xffb347;
-
-    for (let c = 0; c < this.cols.length; c++) {
-      const cx = xs[c] + c * this.colGap;
-      const trackW = (xs[c + 1] - xs[c]);
-      g.lineStyle(0);
-      g.beginFill(colorForCol(this.cols[c]), 0.06);
-      g.drawRect(cx, y0, trackW, h0);
-      g.endFill();
-    }
-
-    for (let c = 0; c < this.cols.length - 1; c++) {
-      const gx = xs[c + 1] + c * this.colGap;
-      g.beginFill(GAP_FILL, GAP_ALPHA);
-      g.drawRect(gx, y0, this.colGap, h0);
-      g.endFill();
-    }
-    for (let r = 0; r < this.rows.length - 1; r++) {
-      const gy = ys[r + 1] + r * this.rowGap;
-      g.beginFill(GAP_FILL, GAP_ALPHA);
-      g.drawRect(x0, gy, w0, this.rowGap);
-      g.endFill();
-    }
-
-    g.lineStyle({ width: 2, color: STROKE, alpha: GRID_LINE_ALPHA, alignment: 0 });
-    for (let c = 0; c <= this.cols.length; c++) {
-      const bx = (c < this.cols.length)
-        ? xs[c] + c * this.colGap
-        : xs[c] + (c - 1) * this.colGap;
-      g.moveTo(bx, y0); g.lineTo(bx, y0 + h0);
-    }
-    for (let r = 0; r <= this.rows.length; r++) {
-      const by = (r < this.rows.length)
-        ? ys[r] + r * this.rowGap
-        : ys[r] + (r - 1) * this.rowGap;
-      g.moveTo(x0, by); g.lineTo(x0 + w0, by);
-    }
-
-    for (let r = 0; r < this.rows.length; r++) {
-      for (let c = 0; c < this.cols.length; c++) {
-        const cx = xs[c] + c * this.colGap;
-        const cy = ys[r] + r * this.rowGap;
-        const cw = (xs[c + 1] - xs[c]);
-        const ch = (ys[r + 1] - ys[r]);
-        g.lineStyle({ width: 1, color: STROKE, alpha: 0.5, alignment: 0 });
-        g.drawRect(cx, cy, cw, ch);
-      }
-    }
-
-    const ring = (x:number,y:number,w:number,h:number,l:number,t:number,rn:number,b:number,color:number,alpha:number) => {
-      if (w <= 0 || h <= 0) return;
-      g.lineStyle(0);
-      g.beginFill(color, alpha);
-      if (t > 0) g.drawRect(x, y, w, t);
-      if (b > 0) g.drawRect(x, y + h - b, w, b);
-      const midH = h - t - b;
-      if (midH > 0) {
-        if (l > 0) g.drawRect(x, y + t, l, midH);
-        if (rn > 0) g.drawRect(x + w - rn, y + t, rn, midH);
-      }
-      g.endFill();
-    };
-
-    for (const ch of this.children) {
-      let r = (rowMap.get(ch) ?? 0) | 0;
-      let c = (colMap.get(ch) ?? 0) | 0;
-      r = Math.min(Math.max(0, r), this.rows.length - 1);
-      c = Math.min(Math.max(0, c), this.cols.length - 1);
-      let rs = (rowSpan.get(ch) ?? 1) | 0;
-      let cs = (colSpan.get(ch) ?? 1) | 0;
-      rs = Math.min(Math.max(1, rs), this.rows.length - r);
-      cs = Math.min(Math.max(1, cs), this.cols.length - c);
-
-      const slotX = xs[c] + c * this.colGap;
-      const slotY = ys[r] + r * this.rowGap;
-      const slotW = (xs[c + cs] - xs[c]) + (cs - 1) * this.colGap;
-      const slotH = (ys[r + rs] - ys[r]) + (rs - 1) * this.rowGap;
-
-      const m = ch.margin;
-      if (m.l || m.t || m.r || m.b) {
-        ring(slotX, slotY, slotW, slotH, m.l, m.t, m.r, m.b, MARGIN_FILL, MARGIN_ALPHA);
-      }
-
-      if (ch instanceof BorderPanel) {
-        const pad = ch.padding;
-        const bx = ch.final.x, by = ch.final.y, bw = ch.final.width, bh = ch.final.height;
-        if (pad.l || pad.t || pad.r || pad.b) {
-          ring(bx, by, bw, bh, pad.l, pad.t, pad.r, pad.b, PADDING_FILL, PADDING_ALPHA);
-        }
-      }
-    }
+    this.debugLayer?.draw(this, xs, ys);
   }
 }

--- a/packages/runtime/src/elements/GridDebug.ts
+++ b/packages/runtime/src/elements/GridDebug.ts
@@ -1,0 +1,133 @@
+import type { Renderer, RenderGraphics } from '../renderer.js';
+import { BorderPanel } from './BorderPanel.js';
+import { Grid } from './Grid.js';
+import type { Col } from './Grid.js';
+
+export interface GridDebugLayer {
+  g: RenderGraphics;
+  draw(grid: Grid, xs: number[], ys: number[]): void;
+}
+
+export function createGridDebug(renderer: Renderer): GridDebugLayer {
+  const g = renderer.createGraphics();
+  g.setVisible?.(false);
+  (g.getDisplayObject() as any).zIndex = 100000;
+
+  const draw = (grid: Grid, xs: number[], ys: number[]) => {
+    g.setVisible?.(grid.debug);
+    g.clear();
+    if (!grid.debug) return;
+    if (grid.final.width <= 0 || grid.final.height <= 0) return;
+
+    const x0 = grid.final.x, y0 = grid.final.y;
+    const w0 = grid.final.width, h0 = grid.final.height;
+
+    const STROKE = 0x00ffff;
+    const STROKE_ALPHA = 0.7;
+    const GRID_LINE_ALPHA = 0.45;
+    const GAP_FILL = 0xff00ff;
+    const GAP_ALPHA = 0.10;
+    const MARGIN_FILL = 0xff9900;
+    const MARGIN_ALPHA = 0.22;
+    const PADDING_FILL = 0x66ccff;
+    const PADDING_ALPHA = 0.18;
+
+    g.lineStyle?.({ width: 2, color: STROKE, alpha: STROKE_ALPHA });
+    g.drawRect(x0, y0, w0, h0);
+
+    const colorForCol = (c: Col) =>
+      c.len.kind === 'px' ? 0x3da5ff : c.len.kind === 'auto' ? 0x5fff7a : 0xffb347;
+
+    for (let c = 0; c < grid.cols.length; c++) {
+      const cx = xs[c] + c * grid.colGap;
+      const trackW = (xs[c + 1] - xs[c]);
+      g.lineStyle?.({ width: 0, color: 0, alpha: 0 });
+      g.beginFill(colorForCol(grid.cols[c]), 0.06);
+      g.drawRect(cx, y0, trackW, h0);
+      g.endFill();
+    }
+
+    for (let c = 0; c < grid.cols.length - 1; c++) {
+      const gx = xs[c + 1] + c * grid.colGap;
+      g.beginFill(GAP_FILL, GAP_ALPHA);
+      g.drawRect(gx, y0, grid.colGap, h0);
+      g.endFill();
+    }
+    for (let r = 0; r < grid.rows.length - 1; r++) {
+      const gy = ys[r + 1] + r * grid.rowGap;
+      g.beginFill(GAP_FILL, GAP_ALPHA);
+      g.drawRect(x0, gy, w0, grid.rowGap);
+      g.endFill();
+    }
+
+    g.lineStyle?.({ width: 2, color: STROKE, alpha: GRID_LINE_ALPHA });
+    for (let c = 0; c <= grid.cols.length; c++) {
+      const bx = (c < grid.cols.length)
+        ? xs[c] + c * grid.colGap
+        : xs[c] + (c - 1) * grid.colGap;
+      g.moveTo?.(bx, y0); g.lineTo?.(bx, y0 + h0);
+    }
+    for (let r = 0; r <= grid.rows.length; r++) {
+      const by = (r < grid.rows.length)
+        ? ys[r] + r * grid.rowGap
+        : ys[r] + (r - 1) * grid.rowGap;
+      g.moveTo?.(x0, by); g.lineTo?.(x0 + w0, by);
+    }
+
+    for (let r = 0; r < grid.rows.length; r++) {
+      for (let c = 0; c < grid.cols.length; c++) {
+        const cx = xs[c] + c * grid.colGap;
+        const cy = ys[r] + r * grid.rowGap;
+        const cw = (xs[c + 1] - xs[c]);
+        const ch = (ys[r + 1] - ys[r]);
+        g.lineStyle?.({ width: 1, color: STROKE, alpha: 0.5 });
+        g.drawRect(cx, cy, cw, ch);
+      }
+    }
+
+    const ring = (x:number,y:number,w:number,h:number,l:number,t:number,rn:number,b:number,color:number,alpha:number) => {
+      if (w <= 0 || h <= 0) return;
+      g.lineStyle?.({ width: 0, color, alpha });
+      g.beginFill(color, alpha);
+      if (t > 0) g.drawRect(x, y, w, t);
+      if (b > 0) g.drawRect(x, y + h - b, w, b);
+      const midH = h - t - b;
+      if (midH > 0) {
+        if (l > 0) g.drawRect(x, y + t, l, midH);
+        if (rn > 0) g.drawRect(x + w - rn, y + t, rn, midH);
+      }
+      g.endFill();
+    };
+
+    for (const ch of grid.children) {
+      let r = Grid.getRow(ch) ?? 0;
+      let c = Grid.getCol(ch) ?? 0;
+      r = Math.min(Math.max(0, r), grid.rows.length - 1);
+      c = Math.min(Math.max(0, c), grid.cols.length - 1);
+      let rs = Grid.getRowSpan(ch) ?? 1;
+      let cs = Grid.getColSpan(ch) ?? 1;
+      rs = Math.min(Math.max(1, rs), grid.rows.length - r);
+      cs = Math.min(Math.max(1, cs), grid.cols.length - c);
+
+      const slotX = xs[c] + c * grid.colGap;
+      const slotY = ys[r] + r * grid.rowGap;
+      const slotW = (xs[c + cs] - xs[c]) + (cs - 1) * grid.colGap;
+      const slotH = (ys[r + rs] - ys[r]) + (rs - 1) * grid.rowGap;
+
+      const m = ch.margin;
+      if (m.l || m.t || m.r || m.b) {
+        ring(slotX, slotY, slotW, slotH, m.l, m.t, m.r, m.b, MARGIN_FILL, MARGIN_ALPHA);
+      }
+
+      if (ch instanceof BorderPanel) {
+        const pad = ch.padding;
+        const bx = ch.final.x, by = ch.final.y, bw = ch.final.width, bh = ch.final.height;
+        if (pad.l || pad.t || pad.r || pad.b) {
+          ring(bx, by, bw, bh, pad.l, pad.t, pad.r, pad.b, PADDING_FILL, PADDING_ALPHA);
+        }
+      }
+    }
+  };
+
+  return { g, draw };
+}

--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -15,10 +15,14 @@ export interface RenderText {
 
 export interface RenderGraphics {
   clear(): void;
-  beginFill(color: number): RenderGraphics;
+  beginFill(color: number, alpha?: number): RenderGraphics;
   drawRect(x: number, y: number, w: number, h: number): RenderGraphics;
+  lineStyle?(opts: { width: number; color: number; alpha?: number }): RenderGraphics;
+  moveTo?(x: number, y: number): RenderGraphics;
+  lineTo?(x: number, y: number): RenderGraphics;
   endFill(): void;
   destroy(): void;
+  setVisible?(v: boolean): void;
   getDisplayObject(): any;
 }
 

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -15,7 +15,23 @@ export const RuntimeInstance = {
       const child = (u as any).child as UIElement | undefined;
       if (child) visit(child, f);
     };
-    const setGridDebug = (on: boolean) => visit(root, g => { g.debug = on; });
+    const setGridDebug = async (on: boolean) => {
+      if (on) {
+        const { createGridDebug } = await import('./elements/GridDebug.js');
+        visit(root, g => {
+          if (!g.debugLayer) {
+            g.debugLayer = createGridDebug(renderer);
+            container.addChild(g.debugLayer.g.getDisplayObject());
+          }
+          g.debug = true;
+        });
+      } else {
+        visit(root, g => {
+          g.debug = false;
+          g.debugLayer?.g.setVisible?.(false);
+        });
+      }
+    };
 
     const layout = (size: Size) => {
       root.measure(size);


### PR DESCRIPTION
## Summary
- isolate grid debug rendering into a lazily loaded module using the abstract renderer
- extend RenderGraphics and pixi renderer with debug drawing primitives
- document async `setGridDebug` workflow

## Testing
- `pnpm -F @noxigui/runtime build`
- `pnpm -F @noxigui/parser build`
- `pnpm -F @noxigui/renderer-pixi build`


------
https://chatgpt.com/codex/tasks/task_e_68b0d14c1494832ab51bffcfa8f2a8b8