### PR TITLE
Add runtime layout tests with mock renderer

### DIFF
--- a/packages/parser/src/parsers/GridParser.ts
+++ b/packages/parser/src/parsers/GridParser.ts
@@ -38,10 +38,12 @@ export class GridParser implements ElementParser {
   collect(into: PIXI.Container, el: UIElement, collect: (into: PIXI.Container, el: UIElement) => void) {
     if (el instanceof Grid) {
       for (const ch of el.children) collect(into, ch);
-      el.debugG.zIndex = 100000;
-      if (el.debugG.parent !== into) {
-        el.debugG.parent?.removeChild(el.debugG);
-        into.addChild(el.debugG);
+      if (el.debugG) {
+        el.debugG.zIndex = 100000;
+        if (el.debugG.parent !== into) {
+          el.debugG.parent?.removeChild(el.debugG);
+          into.addChild(el.debugG);
+        }
       }
       return true;
     }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -6,13 +6,15 @@
   "types": "dist/runtime/src/index.d.ts",
   "exports": "./dist/runtime/src/index.js",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "test": "tsc -p tsconfig.json && node --test dist/runtime/tests/**/*.test.js"
   },
   "dependencies": {
     "pixi.js": "^7.4.3",
     "@noxigui/parser": "file:../parser"
   },
   "devDependencies": {
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "@types/node": "^20.11.30"
   }
 }

--- a/packages/runtime/src/elements/Grid.ts
+++ b/packages/runtime/src/elements/Grid.ts
@@ -20,7 +20,7 @@ export class Grid extends UIElement {
   colGap = 0;
 
   debug = false;
-  debugG = new PIXI.Graphics();
+  debugG: PIXI.Graphics | null = null;
 
   add(ch: UIElement) { this.children.push(ch); }
   static setRow(el: UIElement, i: number) { rowMap.set(el, i|0); }
@@ -191,10 +191,17 @@ export class Grid extends UIElement {
   }
 
   private drawDebug(xs: number[], ys: number[]) {
+    if (!this.debug) {
+      if (this.debugG) {
+        this.debugG.visible = false;
+        this.debugG.clear();
+      }
+      return;
+    }
+    if (!this.debugG) this.debugG = new PIXI.Graphics();
     const g = this.debugG;
-    g.visible = this.debug;
+    g.visible = true;
     g.clear();
-    if (!this.debug) return;
     if (this.final.width <= 0 || this.final.height <= 0) return;
 
     const x0 = this.final.x, y0 = this.final.y;

--- a/packages/runtime/tests/elements/BorderPanel.test.ts
+++ b/packages/runtime/tests/elements/BorderPanel.test.ts
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { BorderPanel } from '../../src/elements/BorderPanel.js';
+import { createMockRenderer, TestElement } from '../mocks.js';
+
+const renderer = createMockRenderer();
+
+test('BorderPanel measures child with margin and padding', () => {
+  const child = new TestElement({ width: 50, height: 30 });
+  const bp = new BorderPanel(renderer, { child });
+  bp.margin = { l: 1, t: 1, r: 1, b: 1 };
+  bp.padding = { l: 2, t: 2, r: 2, b: 2 };
+
+  bp.measure({ width: 100, height: 80 });
+
+  assert.deepEqual(child.measureCalls[0], { width: 94, height: 74 });
+  assert.deepEqual(bp.desired, { width: 56, height: 36 });
+});
+
+test('BorderPanel arranges child inside padding', () => {
+  const child = new TestElement({ width: 50, height: 30 });
+  const bp = new BorderPanel(renderer, { child });
+  bp.margin = { l: 1, t: 1, r: 1, b: 1 };
+  bp.padding = { l: 2, t: 2, r: 2, b: 2 };
+
+  bp.arrange({ x: 10, y: 20, width: 100, height: 80 });
+
+  assert.deepEqual(bp.final, { x: 11, y: 21, width: 98, height: 78 });
+  // container position
+  assert.equal((bp.container as any).x, 11);
+  assert.equal((bp.container as any).y, 21);
+  // child arrange rect
+  assert.deepEqual(child.arrangeCalls[0], { x: 2, y: 2, width: 94, height: 74 });
+});

--- a/packages/runtime/tests/elements/Grid.test.ts
+++ b/packages/runtime/tests/elements/Grid.test.ts
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Grid, Row, Col } from '../../src/elements/Grid.js';
+import { TestElement } from '../mocks.js';
+
+test('Grid measures and arranges star tracks', () => {
+  const grid = new Grid();
+  grid.rows = [new Row({ kind: 'star', v: 1 }), new Row({ kind: 'star', v: 1 })];
+  grid.cols = [new Col({ kind: 'star', v: 1 }), new Col({ kind: 'star', v: 1 })];
+
+  const c1 = new TestElement({ width: 10, height: 20 });
+  const c2 = new TestElement({ width: 30, height: 40 });
+  grid.add(c1);
+  grid.add(c2);
+  Grid.setRow(c2, 1);
+  Grid.setCol(c2, 1);
+
+  grid.measure({ width: 200, height: 100 });
+  assert.deepEqual(grid.desired, { width: 200, height: 100 });
+  assert.equal(grid.cols[0].actual, 100);
+  assert.equal(grid.cols[1].actual, 100);
+  assert.equal(grid.rows[0].actual, 50);
+  assert.equal(grid.rows[1].actual, 50);
+
+  grid.arrange({ x: 0, y: 0, width: 200, height: 100 });
+  assert.deepEqual(c1.arrangeCalls[0], { x: 0, y: 0, width: 100, height: 50 });
+  assert.deepEqual(c2.arrangeCalls[0], { x: 100, y: 50, width: 100, height: 50 });
+});

--- a/packages/runtime/tests/elements/Image.test.ts
+++ b/packages/runtime/tests/elements/Image.test.ts
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Image } from '../../src/elements/Image.js';
+import { createMockRenderer } from '../mocks.js';
+
+const renderer = createMockRenderer();
+
+test('Image measure scales uniformly', () => {
+  const img = new Image(renderer);
+  img.setTexture({ width: 100, height: 80 });
+  img.measure({ width: 50, height: 40 });
+  assert.deepEqual(img.desired, { width: 50, height: 40 });
+});
+
+test('Image arrange applies alignment and stretch', () => {
+  const img = new Image(renderer);
+  img.setTexture({ width: 100, height: 80 });
+  img.hAlign = 'Center';
+  img.vAlign = 'Bottom';
+  img.arrange({ x: 0, y: 0, width: 200, height: 200 });
+  assert.deepEqual(img.final, { x: 0, y: 0, width: 200, height: 200 });
+  const sprite = img.sprite as any;
+  assert.equal(sprite.scaleX, 2);
+  assert.equal(sprite.scaleY, 2);
+  assert.equal(sprite.x, 0);
+  assert.equal(sprite.y, 40);
+});

--- a/packages/runtime/tests/elements/Text.test.ts
+++ b/packages/runtime/tests/elements/Text.test.ts
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Text } from '../../src/elements/Text.js';
+import { createMockRenderer } from '../mocks.js';
+
+const renderer = createMockRenderer();
+
+test('Text measure uses word wrap', () => {
+  const txt = new Text(renderer, 'hello world', { fill: '#fff', fontSize: 10 });
+  txt.measure({ width: 40, height: Infinity });
+  assert.deepEqual(txt.desired, { width: 36, height: 20 });
+});
+
+test('Text arrange centers content', () => {
+  const txt = new Text(renderer, 'hello world', { fill: '#fff', fontSize: 10 });
+  txt.hAlign = 'Center';
+  txt.vAlign = 'Center';
+  txt.arrange({ x: 0, y: 0, width: 100, height: 30 });
+  assert.deepEqual(txt.final, { x: 0, y: 0, width: 100, height: 30 });
+  const render = txt.text as any;
+  assert.equal(render.x, 17);
+  assert.equal(render.y, 10);
+});

--- a/packages/runtime/tests/mocks.ts
+++ b/packages/runtime/tests/mocks.ts
@@ -1,0 +1,75 @@
+import type { Renderer, RenderImage, RenderText, RenderGraphics, RenderContainer } from '../src/renderer.js';
+import { UIElement } from '../src/core.js';
+import type { Size, Rect } from '../src/core.js';
+
+class MockRenderGraphics implements RenderGraphics {
+  clear(): void {}
+  beginFill(_color: number): RenderGraphics { return this; }
+  drawRect(_x: number, _y: number, _w: number, _h: number): RenderGraphics { return this; }
+  endFill(): void {}
+  destroy(): void {}
+  getDisplayObject(): any { return this; }
+}
+
+class MockRenderContainer implements RenderContainer {
+  children: any[] = [];
+  x = 0;
+  y = 0;
+  addChild(child: any): void { this.children.push(child); }
+  removeChild(child: any): void { this.children = this.children.filter(c => c !== child); }
+  setPosition(x: number, y: number): void { this.x = x; this.y = y; }
+  setSortableChildren(_value: boolean): void {}
+  setMask(_mask: any | null): void {}
+  getDisplayObject(): any { return this; }
+}
+
+class MockRenderImage implements RenderImage {
+  width: number;
+  height: number;
+  x = 0;
+  y = 0;
+  scaleX = 1;
+  scaleY = 1;
+  constructor(width = 0, height = 0) { this.width = width; this.height = height; }
+  setTexture(tex?: any): void { this.width = tex?.width ?? 0; this.height = tex?.height ?? 0; }
+  setPosition(x: number, y: number): void { this.x = x; this.y = y; }
+  setScale(x: number, y: number): void { this.scaleX = x; this.scaleY = y; }
+  getNaturalSize() { return { width: this.width, height: this.height }; }
+  getDisplayObject(): any { return this; }
+}
+
+class MockRenderText implements RenderText {
+  x = 0;
+  y = 0;
+  private wrapWidth = Infinity;
+  constructor(private content: string, private style: { fill: string; fontSize: number }) {}
+  setWordWrap(width: number, _align: 'left' | 'center' | 'right'): void { this.wrapWidth = width; }
+  getBounds() {
+    const charW = this.style.fontSize * 0.6;
+    const lineH = this.style.fontSize;
+    const perLine = Math.max(1, Math.floor(this.wrapWidth / charW));
+    const lines = Math.max(1, Math.ceil(this.content.length / perLine));
+    const width = Math.min(this.content.length, perLine) * charW;
+    const height = lines * lineH;
+    return { width, height };
+  }
+  setPosition(x: number, y: number): void { this.x = x; this.y = y; }
+  getDisplayObject(): any { return this; }
+}
+
+export function createMockRenderer(): Renderer {
+  return {
+    createImage: (_tex?: any) => new MockRenderImage(_tex?.width, _tex?.height),
+    createText: (text: string, style: { fill: string; fontSize: number }) => new MockRenderText(text, style),
+    createGraphics: () => new MockRenderGraphics(),
+    createContainer: () => new MockRenderContainer(),
+  };
+}
+
+export class TestElement extends UIElement {
+  measureCalls: Size[] = [];
+  arrangeCalls: Rect[] = [];
+  constructor(private desiredSize: Size) { super(); }
+  measure(avail: Size): void { this.measureCalls.push(avail); this.desired = { ...this.desiredSize }; }
+  arrange(rect: Rect): void { this.arrangeCalls.push(rect); this.final = { ...rect }; }
+}

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -5,7 +5,8 @@
     "declaration": true,
     "declarationMap": true,
     "allowImportingTsExtensions": false,
-    "erasableSyntaxOnly": false
+    "erasableSyntaxOnly": false,
+    "types": ["node"]
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
         specifier: ^7.4.3
         version: 7.4.3
     devDependencies:
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.19.11
       typescript:
         specifier: ~5.8.3
         version: 5.8.3


### PR DESCRIPTION
## Summary
- add mock renderer and test suite for runtime elements
- cover BorderPanel, Image, Text and Grid measure/arrange behavior
- make Grid debug graphics optional for headless tests

## Testing
- `pnpm -F @noxigui/runtime test`


------
https://chatgpt.com/codex/tasks/task_e_68b0d151f904832aa98d79783bccad9d