### PR TITLE
refactor: move renderer-agnostic elements to core

### DIFF
--- a/packages/core/src/elements/BorderPanel.ts
+++ b/packages/core/src/elements/BorderPanel.ts
@@ -1,0 +1,48 @@
+import { UIElement, type Size, type Rect } from './UIElement.js';
+
+export class BorderPanel extends UIElement {
+  child?: UIElement;
+  background?: number;
+  clipToBounds = false;
+  padding = { l: 0, t: 0, r: 0, b: 0 };
+
+  constructor(opts?: { background?: number; child?: UIElement }) {
+    super();
+    this.background = opts?.background;
+    this.child = opts?.child;
+  }
+
+  measure(avail: Size) {
+    const inner = {
+      width: Math.max(0, avail.width - this.margin.l - this.margin.r - this.padding.l - this.padding.r),
+      height: Math.max(0, avail.height - this.margin.t - this.margin.b - this.padding.t - this.padding.b),
+    };
+    let intrinsicW = this.margin.l + this.margin.r + this.padding.l + this.padding.r;
+    let intrinsicH = this.margin.t + this.margin.b + this.padding.t + this.padding.b;
+    if (this.child) {
+      this.child.measure(inner);
+      intrinsicW += this.child.desired.width;
+      intrinsicH += this.child.desired.height;
+    }
+    this.desired = {
+      width: this.measureAxis('x', avail.width, intrinsicW),
+      height: this.measureAxis('y', avail.height, intrinsicH),
+    };
+  }
+
+  arrange(rect: Rect) {
+    const innerX = rect.x + this.margin.l;
+    const innerY = rect.y + this.margin.t;
+    const innerW = Math.max(0, rect.width - this.margin.l - this.margin.r);
+    const innerH = Math.max(0, rect.height - this.margin.t - this.margin.b);
+    this.final = { x: innerX, y: innerY, width: innerW, height: innerH };
+
+    if (this.child) {
+      const cx = this.padding.l;
+      const cy = this.padding.t;
+      const cw = Math.max(0, innerW - this.padding.l - this.padding.r);
+      const ch = Math.max(0, innerH - this.padding.t - this.padding.b);
+      this.child.arrange({ x: cx, y: cy, width: cw, height: ch });
+    }
+  }
+}

--- a/packages/core/src/elements/Grid.ts
+++ b/packages/core/src/elements/Grid.ts
@@ -1,0 +1,195 @@
+import { UIElement, type Size, type Rect } from './UIElement.js';
+
+export type Len = { kind: 'auto' | 'px' | 'star'; v: number };
+export class Row { actual = 0; desired = 0; constructor(public len: Len) {} }
+export class Col { actual = 0; desired = 0; constructor(public len: Len) {} }
+
+const rowMap = new WeakMap<UIElement, number>();
+const colMap = new WeakMap<UIElement, number>();
+const rowSpan = new WeakMap<UIElement, number>();
+const colSpan = new WeakMap<UIElement, number>();
+
+export class Grid extends UIElement {
+  rows: Row[] = [];
+  cols: Col[] = [];
+  children: UIElement[] = [];
+  rowGap = 0;
+  colGap = 0;
+  debug = false;
+
+  add(ch: UIElement) { this.children.push(ch); }
+  static setRow(el: UIElement, i: number) { rowMap.set(el, i|0); }
+  static setCol(el: UIElement, i: number) { colMap.set(el, i|0); }
+  static setRowSpan(el: UIElement, n: number) { rowSpan.set(el, Math.max(1, n|0)); }
+  static setColSpan(el: UIElement, n: number) { colSpan.set(el, Math.max(1, n|0)); }
+  static getRow(el: UIElement) { return rowMap.get(el); }
+  static getCol(el: UIElement) { return colMap.get(el); }
+  static getRowSpan(el: UIElement) { return rowSpan.get(el); }
+  static getColSpan(el: UIElement) { return colSpan.get(el); }
+
+  measure(avail: Size) {
+    if (this.rows.length === 0) this.rows.push(new Row({ kind: 'star', v: 1 }));
+    if (this.cols.length === 0) this.cols.push(new Col({ kind: 'star', v: 1 }));
+
+    const innerAvail = {
+      width: Math.max(0, avail.width - this.margin.l - this.margin.r),
+      height: Math.max(0, avail.height - this.margin.t - this.margin.b),
+    };
+
+    const finiteW = Number.isFinite(innerAvail.width);
+    const finiteH = Number.isFinite(innerAvail.height);
+
+    const rowCount = this.rows.length;
+    const colCount = this.cols.length;
+
+    this.rows.forEach(r => { r.actual = r.len.kind === 'px' ? r.len.v : 0; r.desired = 0; });
+    this.cols.forEach(c => { c.actual = c.len.kind === 'px' ? c.len.v : 0; c.desired = 0; });
+
+    const totalRowGaps = Math.max(0, rowCount - 1) * this.rowGap;
+    const totalColGaps = Math.max(0, colCount - 1) * this.colGap;
+
+    const pixelHAll = this.rows.filter(r => r.len.kind === 'px').reduce((s, r) => s + r.len.v, 0);
+    const pixelWAll = this.cols.filter(c => c.len.kind === 'px').reduce((s, c) => s + c.len.v, 0);
+
+    const starHAll = finiteH ? this.rows.filter(r => r.len.kind === 'star').reduce((s, r) => s + r.len.v, 0) : 0;
+    const starWAll = finiteW ? this.cols.filter(c => c.len.kind === 'star').reduce((s, c) => s + c.len.v, 0) : 0;
+
+    const remH0 = finiteH ? Math.max(0, innerAvail.height - pixelHAll - totalRowGaps) : 0;
+    const remW0 = finiteW ? Math.max(0, innerAvail.width - pixelWAll - totalColGaps) : 0;
+
+    const sumPixelCols = (start: number, span: number) => {
+      let s = 0; for (let i = 0; i < span; i++) { const c = this.cols[start + i]; if (c && c.len.kind === 'px') s += c.len.v; }
+      return s;
+    };
+    const sumPixelRows = (start: number, span: number) => {
+      let s = 0; for (let i = 0; i < span; i++) { const r = this.rows[start + i]; if (r && r.len.kind === 'px') s += r.len.v; }
+      return s;
+    };
+    const sumStarCols = (start: number, span: number) => {
+      let s = 0; for (let i = 0; i < span; i++) { const c = this.cols[start + i]; if (c && c.len.kind === 'star') s += c.len.v; }
+      return s;
+    };
+    const sumStarRows = (start: number, span: number) => {
+      let s = 0; for (let i = 0; i < span; i++) { const r = this.rows[start + i]; if (r && r.len.kind === 'star') s += r.len.v; }
+      return s;
+    };
+
+    for (const ch of this.children) {
+      let r = (rowMap.get(ch) ?? 0) | 0;
+      let c = (colMap.get(ch) ?? 0) | 0;
+      r = Math.min(Math.max(0, r), rowCount - 1);
+      c = Math.min(Math.max(0, c), colCount - 1);
+
+      let rs = (rowSpan.get(ch) ?? 1) | 0;
+      let cs = (colSpan.get(ch) ?? 1) | 0;
+      rs = Math.min(Math.max(1, rs), rowCount - r);
+      cs = Math.min(Math.max(1, cs), colCount - c);
+
+      const baseW =
+        sumPixelCols(c, cs) +
+        (starWAll > 0 ? (sumStarCols(c, cs) / starWAll) * remW0 : 0) +
+        (cs - 1) * this.colGap;
+
+      const baseH =
+        sumPixelRows(r, rs) +
+        (starHAll > 0 ? (sumStarRows(r, rs) / starHAll) * remH0 : 0) +
+        (rs - 1) * this.rowGap;
+
+      const hasWidthLimiter = (sumPixelCols(c, cs) > 0) || (finiteW && sumStarCols(c, cs) > 0);
+      const hasHeightLimiter = (sumPixelRows(r, rs) > 0) || (finiteH && sumStarRows(r, rs) > 0);
+
+      const approxW = hasWidthLimiter ? Math.max(1, baseW) : Infinity;
+      const approxH = hasHeightLimiter ? Math.max(1, baseH) : Infinity;
+
+      ch.measure({ width: approxW, height: approxH });
+
+      const perRow = ch.desired.height / rs;
+      for (let i = 0; i < rs; i++) {
+        const row = this.rows[r + i];
+        if (!row) continue;
+        if (row.len.kind === 'auto') row.desired = Math.max(row.desired, perRow);
+        if (!finiteH && row.len.kind === 'star') row.desired = Math.max(row.desired, perRow);
+      }
+
+      const perCol = ch.desired.width / cs;
+      for (let i = 0; i < cs; i++) {
+        const col = this.cols[c + i];
+        if (!col) continue;
+        if (col.len.kind === 'auto') col.desired = Math.max(col.desired, perCol);
+        if (!finiteW && col.len.kind === 'star') col.desired = Math.max(col.desired, perCol);
+      }
+    }
+
+    for (const r of this.rows) if (r.len.kind === 'auto') r.actual = Math.ceil(r.desired);
+    for (const c of this.cols) if (c.len.kind === 'auto') c.actual = Math.ceil(c.desired);
+
+    const usedW = this.cols.reduce((s, c) => s + c.actual, 0);
+    const usedH = this.rows.reduce((s, r) => s + r.actual, 0);
+
+    const remW = finiteW ? Math.max(0, innerAvail.width - usedW - totalColGaps) : 0;
+    const remH = finiteH ? Math.max(0, innerAvail.height - usedH - totalRowGaps) : 0;
+
+    const starWUsed = this.cols.filter(c => c.len.kind === 'star').reduce((s, c) => s + c.len.v, 0);
+    const starHUsed = this.rows.filter(r => r.len.kind === 'star').reduce((s, r) => s + r.len.v, 0);
+
+    for (const c of this.cols) {
+      if (c.len.kind === 'star') {
+        c.actual = finiteW ? (starWUsed ? c.len.v / starWUsed : 0) * remW : Math.ceil(c.desired);
+      }
+    }
+    for (const r of this.rows) {
+      if (r.len.kind === 'star') {
+        r.actual = finiteH ? (starHUsed ? r.len.v / starHUsed : 0) * remH : Math.ceil(r.desired);
+      }
+    }
+
+    const widthSum = this.cols.reduce((s, c) => s + c.actual, 0) + totalColGaps;
+    const heightSum = this.rows.reduce((s, r) => s + r.actual, 0) + totalRowGaps;
+
+    const intrinsicW = widthSum + this.margin.l + this.margin.r;
+    const intrinsicH = heightSum + this.margin.t + this.margin.b;
+    this.desired = {
+      width: this.measureAxis('x', avail.width, intrinsicW),
+      height: this.measureAxis('y', avail.height, intrinsicH),
+    };
+  }
+
+  arrange(rect: Rect) {
+    const rowCount = this.rows.length;
+    const colCount = this.cols.length;
+    const innerX = rect.x + this.margin.l;
+    const innerY = rect.y + this.margin.t;
+    const innerW = Math.max(0, rect.width - this.margin.l - this.margin.r);
+    const innerH = Math.max(0, rect.height - this.margin.t - this.margin.b);
+    this.final = { x: innerX, y: innerY, width: innerW, height: innerH };
+
+    const xs: number[] = [0];
+    for (const c of this.cols) xs.push(xs[xs.length - 1] + c.actual);
+    const ys: number[] = [0];
+    for (const r of this.rows) ys.push(ys[ys.length - 1] + r.actual);
+
+    for (const ch of this.children) {
+      let r = (rowMap.get(ch) ?? 0) | 0;
+      let c = (colMap.get(ch) ?? 0) | 0;
+      r = Math.min(Math.max(0, r), Math.max(0, rowCount - 1));
+      c = Math.min(Math.max(0, c), Math.max(0, colCount - 1));
+
+      let rs = (rowSpan.get(ch) ?? 1) | 0;
+      let cs = (colSpan.get(ch) ?? 1) | 0;
+      rs = Math.min(Math.max(1, rs), Math.max(1, rowCount - r));
+      cs = Math.min(Math.max(1, cs), Math.max(1, colCount - c));
+
+      const x = xs[c] + c * this.colGap;
+      const y = ys[r] + r * this.rowGap;
+
+      const w = (xs[c + cs] - xs[c]) + (cs - 1) * this.colGap;
+      const h = (ys[r + rs] - ys[r]) + (rs - 1) * this.rowGap;
+
+      ch.arrange({ x, y, width: w, height: h });
+    }
+
+    this.postArrange(xs, ys);
+  }
+
+  protected postArrange(_xs: number[], _ys: number[]): void {}
+}

--- a/packages/core/src/elements/Image.ts
+++ b/packages/core/src/elements/Image.ts
@@ -1,0 +1,131 @@
+import { UIElement, type Size, type Rect } from './UIElement.js';
+
+export class Image extends UIElement {
+  hAlign: 'Left' | 'Center' | 'Right' = 'Left';
+  vAlign: 'Top' | 'Center' | 'Bottom' = 'Top';
+  stretch: 'None' | 'Fill' | 'Uniform' | 'UniformToFill' = 'Uniform';
+  protected natW = 0;
+  protected natH = 0;
+  renderX = 0;
+  renderY = 0;
+  renderScaleX = 1;
+  renderScaleY = 1;
+
+  protected setNaturalSize(w: number, h: number) {
+    this.natW = Math.max(0, w);
+    this.natH = Math.max(0, h);
+  }
+
+  measure(avail: Size) {
+    const natW = this.natW || 0;
+    const natH = this.natH || 0;
+
+    const fallback = 180; // default so card doesn't collapse
+    const baseW = natW > 0 ? natW : fallback;
+    const baseH = natH > 0 ? natH : fallback;
+
+    if (this.prefW !== undefined && this.prefH !== undefined) {
+      const intrinsicW = this.prefW + this.margin.l + this.margin.r;
+      const intrinsicH = this.prefH + this.margin.t + this.margin.b;
+      this.desired = {
+        width: this.measureAxis('x', avail.width, intrinsicW),
+        height: this.measureAxis('y', avail.height, intrinsicH)
+      };
+      return;
+    }
+
+    if (this.prefW !== undefined && this.prefH === undefined) {
+      const h = baseH * (this.prefW / baseW);
+      const intrinsicW = this.prefW + this.margin.l + this.margin.r;
+      const intrinsicH = h + this.margin.t + this.margin.b;
+      this.desired = {
+        width: this.measureAxis('x', avail.width, intrinsicW),
+        height: this.measureAxis('y', avail.height, intrinsicH)
+      };
+      return;
+    }
+    if (this.prefH !== undefined && this.prefW === undefined) {
+      const w = baseW * (this.prefH / baseH);
+      const intrinsicW = w + this.margin.l + this.margin.r;
+      const intrinsicH = this.prefH + this.margin.t + this.margin.b;
+      this.desired = {
+        width: this.measureAxis('x', avail.width, intrinsicW),
+        height: this.measureAxis('y', avail.height, intrinsicH)
+      };
+      return;
+    }
+
+    const hasW = Number.isFinite(avail.width);
+    const hasH = Number.isFinite(avail.height);
+
+    let drawW = baseW;
+    let drawH = baseH;
+
+    if (this.stretch === 'None') {
+    } else if (this.stretch === 'Fill') {
+      drawW = hasW ? Math.min(avail.width, baseW) : baseW;
+      drawH = hasH ? Math.min(avail.height, baseH) : baseH;
+    } else if (this.stretch === 'Uniform') {
+      if (hasW && hasH) {
+        const s = Math.min(avail.width / baseW, avail.height / baseH, 1);
+        drawW = baseW * s; drawH = baseH * s;
+      } else if (hasW && !hasH) {
+        const s = Math.min(avail.width / baseW, 1);
+        drawW = baseW * s; drawH = baseH * s;
+      } else if (!hasW && hasH) {
+        const s = Math.min(avail.height / baseH, 1);
+        drawW = baseW * s; drawH = baseH * s;
+      } else {
+        drawW = baseW; drawH = baseH;
+      }
+    } else if (this.stretch === 'UniformToFill') {
+      if (hasW && hasH) {
+        const s = Math.min(Math.max(avail.width / baseW, avail.height / baseH), 1);
+        drawW = baseW * s; drawH = baseH * s;
+      } else if (hasW && !hasH) {
+        const s = Math.min(avail.width / baseW, 1);
+        drawW = baseW * s; drawH = baseH * s;
+      } else if (!hasW && hasH) {
+        const s = Math.min(avail.height / baseH, 1);
+        drawW = baseW * s; drawH = baseH * s;
+      } else {
+        drawW = baseW; drawH = baseH;
+      }
+    }
+
+    const intrinsicW = drawW + this.margin.l + this.margin.r;
+    const intrinsicH = drawH + this.margin.t + this.margin.b;
+    this.desired = {
+      width: this.measureAxis('x', avail.width, intrinsicW),
+      height: this.measureAxis('y', avail.height, intrinsicH)
+    };
+  }
+
+  arrange(rect: Rect) {
+    const x0 = rect.x + this.margin.l, y0 = rect.y + this.margin.t;
+    const w = Math.max(0, rect.width - this.margin.l - this.margin.r);
+    const h = Math.max(0, rect.height - this.margin.t - this.margin.b);
+    this.final = { x: x0, y: y0, width: w, height: h };
+
+    const sw = this.natW || 1, sh = this.natH || 1;
+    let scaleX = 1, scaleY = 1, drawW = sw, drawH = sh;
+
+    switch (this.stretch) {
+      case 'None': { scaleX = scaleY = 1; drawW = sw; drawH = sh; break; }
+      case 'Fill': { scaleX = w / sw; scaleY = h / sh; drawW = w; drawH = h; break; }
+      case 'Uniform': { const s = Math.min(w / sw, h / sh); scaleX = scaleY = s; drawW = sw * s; drawH = sh * s; break; }
+      case 'UniformToFill': { const s = Math.max(w / sw, h / sh); scaleX = scaleY = s; drawW = sw * s; drawH = sh * s; break; }
+    }
+
+    let x = x0, y = y0;
+    if (this.hAlign === 'Center') x = x0 + (w - drawW) / 2;
+    else if (this.hAlign === 'Right') x = x0 + (w - drawW);
+    if (this.vAlign === 'Center') y = y0 + (h - drawH) / 2;
+    else if (this.vAlign === 'Bottom') y = y0 + (h - drawH);
+
+    this.renderScaleX = scaleX;
+    this.renderScaleY = scaleY;
+    this.renderX = x;
+    this.renderY = y;
+  }
+}

--- a/packages/core/src/elements/Text.ts
+++ b/packages/core/src/elements/Text.ts
@@ -1,0 +1,51 @@
+import { UIElement, type Size, type Rect } from './UIElement.js';
+
+export abstract class Text extends UIElement {
+  content: string;
+  style: { fill: string; fontSize: number };
+  hAlign: 'Left' | 'Center' | 'Right' = 'Left';
+  vAlign: 'Top' | 'Center' | 'Bottom' = 'Top';
+  renderX = 0;
+  renderY = 0;
+  renderWidth = 0;
+  renderHeight = 0;
+
+  constructor(content: string, style: { fill: string; fontSize: number }) {
+    super();
+    this.content = content;
+    this.style = style;
+  }
+
+  protected abstract measureText(width: number, align: 'left' | 'center' | 'right'): Size;
+
+  measure(avail: Size) {
+    const b = this.measureText(Math.max(1, avail.width), 'left');
+    const intrinsicW = b.width + this.margin.l + this.margin.r;
+    const intrinsicH = b.height + this.margin.t + this.margin.b;
+    this.desired = {
+      width: this.measureAxis('x', avail.width, intrinsicW),
+      height: this.measureAxis('y', avail.height, intrinsicH)
+    };
+  }
+
+  arrange(rect: Rect) {
+    const x0 = rect.x + this.margin.l, y0 = rect.y + this.margin.t;
+    const w = Math.max(0, rect.width - this.margin.l - this.margin.r);
+    const h = Math.max(0, rect.height - this.margin.t - this.margin.b);
+    this.final = { x: x0, y: y0, width: w, height: h };
+
+    const align = this.hAlign === 'Center' ? 'center' : this.hAlign === 'Right' ? 'right' : 'left';
+    const b = this.measureText(Math.max(1, w), align);
+
+    let x = x0, y = y0;
+    if (this.hAlign === 'Center') x = x0 + (w - b.width) / 2;
+    else if (this.hAlign === 'Right') x = x0 + (w - b.width);
+    if (this.vAlign === 'Center') y = y0 + (h - b.height) / 2;
+    else if (this.vAlign === 'Bottom') y = y0 + (h - b.height);
+
+    this.renderX = x;
+    this.renderY = y;
+    this.renderWidth = b.width;
+    this.renderHeight = b.height;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,3 +3,7 @@ export * from './layout/register-defaults.js';
 export * from './layout/rules/basic.js';
 export * from './layout/rules/extra.js';
 export * from './elements/UIElement.js';
+export * from './elements/BorderPanel.js';
+export * from './elements/Grid.js';
+export * from './elements/Image.js';
+export * from './elements/Text.js';

--- a/packages/parser/src/parsers/GridParser.ts
+++ b/packages/parser/src/parsers/GridParser.ts
@@ -1,4 +1,5 @@
-import { Grid, Row, Col } from '../../../runtime/src/elements/Grid.js';
+import { Grid } from '../../../runtime/src/elements/Grid.js';
+import { Row, Col } from '../../../core/src/index.js';
 import { applyGridAttachedProps, parseLen, applyMargin } from '../../../runtime/src/helpers.js';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';

--- a/packages/runtime/src/elements/BorderPanel.ts
+++ b/packages/runtime/src/elements/BorderPanel.ts
@@ -1,58 +1,30 @@
-import { UIElement } from '../../../core/src/index.js';
-import type { Size, Rect } from '../../../core/src/index.js';
+import type { Rect } from '../../../core/src/index.js';
+import { BorderPanel as CoreBorderPanel, type UIElement } from '../../../core/src/index.js';
 import type { Renderer, RenderGraphics, RenderContainer } from '../renderer.js';
 
-export class BorderPanel extends UIElement {
+export class BorderPanel extends CoreBorderPanel {
   bg: RenderGraphics;
   container: RenderContainer;
-  child?: UIElement;
-  background?: number;
-  clipToBounds = false;
   private maskG: RenderGraphics | null = null;
-  padding = { l: 0, t: 0, r: 0, b: 0 };
   private renderer: Renderer;
 
   constructor(renderer: Renderer, opts?: { background?: number; child?: UIElement }) {
-    super();
+    super(opts);
     this.renderer = renderer;
     this.container = renderer.createContainer();
     this.bg = renderer.createGraphics();
     this.container.addChild(this.bg.getDisplayObject());
-    this.background = opts?.background;
-    this.child = opts?.child;
-  }
-
-  measure(avail: Size) {
-    const inner = {
-      width: Math.max(0, avail.width - this.margin.l - this.margin.r - this.padding.l - this.padding.r),
-      height: Math.max(0, avail.height - this.margin.t - this.margin.b - this.padding.t - this.padding.b),
-    };
-    let intrinsicW = this.margin.l + this.margin.r + this.padding.l + this.padding.r;
-    let intrinsicH = this.margin.t + this.margin.b + this.padding.t + this.padding.b;
-    if (this.child) {
-      this.child.measure(inner);
-      intrinsicW += this.child.desired.width;
-      intrinsicH += this.child.desired.height;
-    }
-    this.desired = {
-      width: this.measureAxis('x', avail.width, intrinsicW),
-      height: this.measureAxis('y', avail.height, intrinsicH),
-    };
   }
 
   arrange(rect: Rect) {
-    const innerX = rect.x + this.margin.l;
-    const innerY = rect.y + this.margin.t;
-    const innerW = Math.max(0, rect.width - this.margin.l - this.margin.r);
-    const innerH = Math.max(0, rect.height - this.margin.t - this.margin.b);
-    this.final = { x: innerX, y: innerY, width: innerW, height: innerH };
+    super.arrange(rect);
 
-    this.container.setPosition(innerX, innerY);
+    this.container.setPosition(this.final.x, this.final.y);
     this.container.setSortableChildren(true);
 
     this.bg.clear();
     if (this.background !== undefined) {
-      this.bg.beginFill(this.background).drawRect(0, 0, innerW, innerH).endFill();
+      this.bg.beginFill(this.background).drawRect(0, 0, this.final.width, this.final.height).endFill();
     }
 
     if (this.clipToBounds) {
@@ -62,20 +34,12 @@ export class BorderPanel extends UIElement {
         this.container.setMask(this.maskG.getDisplayObject());
       }
       this.maskG.clear();
-      this.maskG.beginFill(0xffffff).drawRect(0, 0, innerW, innerH).endFill();
+      this.maskG.beginFill(0xffffff).drawRect(0, 0, this.final.width, this.final.height).endFill();
     } else if (this.maskG) {
       this.container.setMask(null);
       this.container.removeChild(this.maskG.getDisplayObject());
       this.maskG.destroy();
       this.maskG = null;
-    }
-
-    if (this.child) {
-      const cx = this.padding.l;
-      const cy = this.padding.t;
-      const cw = Math.max(0, innerW - this.padding.l - this.padding.r);
-      const ch = Math.max(0, innerH - this.padding.t - this.padding.b);
-      this.child.arrange({ x: cx, y: cy, width: cw, height: ch });
     }
   }
 }

--- a/packages/runtime/src/elements/Grid.ts
+++ b/packages/runtime/src/elements/Grid.ts
@@ -1,198 +1,13 @@
 import * as PIXI from 'pixi.js';
-import { UIElement } from '../../../core/src/index.js';
-import type { Size, Rect } from '../../../core/src/index.js';
-import type { Len } from '../helpers.js';
+import { Grid as CoreGrid, Col } from '../../../core/src/index.js';
 import { BorderPanel } from './BorderPanel.js';
 
-export class Row { actual = 0; desired = 0; constructor(public len: Len) {} }
-export class Col { actual = 0; desired = 0; constructor(public len: Len) {} }
+export { Row, Col } from '../../../core/src/index.js';
 
-const rowMap = new WeakMap<UIElement, number>();
-const colMap = new WeakMap<UIElement, number>();
-const rowSpan = new WeakMap<UIElement, number>();
-const colSpan = new WeakMap<UIElement, number>();
-
-export class Grid extends UIElement {
-  rows: Row[] = [];
-  cols: Col[] = [];
-  children: UIElement[] = [];
-  rowGap = 0;
-  colGap = 0;
-
-  debug = false;
+export class Grid extends CoreGrid {
   debugG = new PIXI.Graphics();
 
-  add(ch: UIElement) { this.children.push(ch); }
-  static setRow(el: UIElement, i: number) { rowMap.set(el, i|0); }
-  static setCol(el: UIElement, i: number) { colMap.set(el, i|0); }
-  static setRowSpan(el: UIElement, n: number) { rowSpan.set(el, Math.max(1, n|0)); }
-  static setColSpan(el: UIElement, n: number) { colSpan.set(el, Math.max(1, n|0)); }
-
-  measure(avail: Size) {
-    if (this.rows.length === 0) this.rows.push(new Row({ kind: 'star', v: 1 }));
-    if (this.cols.length === 0) this.cols.push(new Col({ kind: 'star', v: 1 }));
-
-    const innerAvail = {
-      width: Math.max(0, avail.width - this.margin.l - this.margin.r),
-      height: Math.max(0, avail.height - this.margin.t - this.margin.b),
-    };
-
-    const finiteW = Number.isFinite(innerAvail.width);
-    const finiteH = Number.isFinite(innerAvail.height);
-
-    const rowCount = this.rows.length;
-    const colCount = this.cols.length;
-
-    this.rows.forEach(r => { r.actual = r.len.kind === 'px' ? r.len.v : 0; r.desired = 0; });
-    this.cols.forEach(c => { c.actual = c.len.kind === 'px' ? c.len.v : 0; c.desired = 0; });
-
-    const totalRowGaps = Math.max(0, rowCount - 1) * this.rowGap;
-    const totalColGaps = Math.max(0, colCount - 1) * this.colGap;
-
-    const pixelHAll = this.rows.filter(r => r.len.kind === 'px').reduce((s, r) => s + r.len.v, 0);
-    const pixelWAll = this.cols.filter(c => c.len.kind === 'px').reduce((s, c) => s + c.len.v, 0);
-
-    const starHAll = finiteH ? this.rows.filter(r => r.len.kind === 'star').reduce((s, r) => s + r.len.v, 0) : 0;
-    const starWAll = finiteW ? this.cols.filter(c => c.len.kind === 'star').reduce((s, c) => s + c.len.v, 0) : 0;
-
-    const remH0 = finiteH ? Math.max(0, innerAvail.height - pixelHAll - totalRowGaps) : 0;
-    const remW0 = finiteW ? Math.max(0, innerAvail.width - pixelWAll - totalColGaps) : 0;
-
-    const sumPixelCols = (start: number, span: number) => {
-      let s = 0; for (let i = 0; i < span; i++) { const c = this.cols[start + i]; if (c && c.len.kind === 'px') s += c.len.v; }
-      return s;
-    };
-    const sumPixelRows = (start: number, span: number) => {
-      let s = 0; for (let i = 0; i < span; i++) { const r = this.rows[start + i]; if (r && r.len.kind === 'px') s += r.len.v; }
-      return s;
-    };
-    const sumStarCols = (start: number, span: number) => {
-      let s = 0; for (let i = 0; i < span; i++) { const c = this.cols[start + i]; if (c && c.len.kind === 'star') s += c.len.v; }
-      return s;
-    };
-    const sumStarRows = (start: number, span: number) => {
-      let s = 0; for (let i = 0; i < span; i++) { const r = this.rows[start + i]; if (r && r.len.kind === 'star') s += r.len.v; }
-      return s;
-    };
-
-    for (const ch of this.children) {
-      let r = (rowMap.get(ch) ?? 0) | 0;
-      let c = (colMap.get(ch) ?? 0) | 0;
-      r = Math.min(Math.max(0, r), rowCount - 1);
-      c = Math.min(Math.max(0, c), colCount - 1);
-
-      let rs = (rowSpan.get(ch) ?? 1) | 0;
-      let cs = (colSpan.get(ch) ?? 1) | 0;
-      rs = Math.min(Math.max(1, rs), rowCount - r);
-      cs = Math.min(Math.max(1, cs), colCount - c);
-
-      const baseW =
-        sumPixelCols(c, cs) +
-        (starWAll > 0 ? (sumStarCols(c, cs) / starWAll) * remW0 : 0) +
-        (cs - 1) * this.colGap;
-
-      const baseH =
-        sumPixelRows(r, rs) +
-        (starHAll > 0 ? (sumStarRows(r, rs) / starHAll) * remH0 : 0) +
-        (rs - 1) * this.rowGap;
-
-      const hasWidthLimiter = (sumPixelCols(c, cs) > 0) || (finiteW && sumStarCols(c, cs) > 0);
-      const hasHeightLimiter = (sumPixelRows(r, rs) > 0) || (finiteH && sumStarRows(r, rs) > 0);
-
-      const approxW = hasWidthLimiter ? Math.max(1, baseW) : Infinity;
-      const approxH = hasHeightLimiter ? Math.max(1, baseH) : Infinity;
-
-      ch.measure({ width: approxW, height: approxH });
-
-      const perRow = ch.desired.height / rs;
-      for (let i = 0; i < rs; i++) {
-        const row = this.rows[r + i];
-        if (!row) continue;
-        if (row.len.kind === 'auto') row.desired = Math.max(row.desired, perRow);
-        if (!finiteH && row.len.kind === 'star') row.desired = Math.max(row.desired, perRow);
-      }
-
-      const perCol = ch.desired.width / cs;
-      for (let i = 0; i < cs; i++) {
-        const col = this.cols[c + i];
-        if (!col) continue;
-        if (col.len.kind === 'auto') col.desired = Math.max(col.desired, perCol);
-        if (!finiteW && col.len.kind === 'star') col.desired = Math.max(col.desired, perCol);
-      }
-    }
-
-    for (const r of this.rows) if (r.len.kind === 'auto') r.actual = Math.ceil(r.desired);
-    for (const c of this.cols) if (c.len.kind === 'auto') c.actual = Math.ceil(c.desired);
-
-    const usedW = this.cols.reduce((s, c) => s + c.actual, 0);
-    const usedH = this.rows.reduce((s, r) => s + r.actual, 0);
-
-    const remW = finiteW ? Math.max(0, innerAvail.width - usedW - totalColGaps) : 0;
-    const remH = finiteH ? Math.max(0, innerAvail.height - usedH - totalRowGaps) : 0;
-
-    const starWUsed = this.cols.filter(c => c.len.kind === 'star').reduce((s, c) => s + c.len.v, 0);
-    const starHUsed = this.rows.filter(r => r.len.kind === 'star').reduce((s, r) => s + r.len.v, 0);
-
-    for (const c of this.cols) {
-      if (c.len.kind === 'star') {
-        c.actual = finiteW ? (starWUsed ? c.len.v / starWUsed : 0) * remW : Math.ceil(c.desired);
-      }
-    }
-    for (const r of this.rows) {
-      if (r.len.kind === 'star') {
-        r.actual = finiteH ? (starHUsed ? r.len.v / starHUsed : 0) * remH : Math.ceil(r.desired);
-      }
-    }
-
-    const widthSum = this.cols.reduce((s, c) => s + c.actual, 0) + totalColGaps;
-    const heightSum = this.rows.reduce((s, r) => s + r.actual, 0) + totalRowGaps;
-
-    const intrinsicW = widthSum + this.margin.l + this.margin.r;
-    const intrinsicH = heightSum + this.margin.t + this.margin.b;
-    this.desired = {
-      width: this.measureAxis('x', avail.width, intrinsicW),
-      height: this.measureAxis('y', avail.height, intrinsicH),
-    };
-  }
-
-  arrange(rect: Rect) {
-    const rowCount = this.rows.length;
-    const colCount = this.cols.length;
-    const innerX = rect.x + this.margin.l;
-    const innerY = rect.y + this.margin.t;
-    const innerW = Math.max(0, rect.width - this.margin.l - this.margin.r);
-    const innerH = Math.max(0, rect.height - this.margin.t - this.margin.b);
-    this.final = { x: innerX, y: innerY, width: innerW, height: innerH };
-
-    const xs: number[] = [0];
-    for (const c of this.cols) xs.push(xs[xs.length - 1] + c.actual);
-    const ys: number[] = [0];
-    for (const r of this.rows) ys.push(ys[ys.length - 1] + r.actual);
-
-    for (const ch of this.children) {
-      let r = (rowMap.get(ch) ?? 0) | 0;
-      let c = (colMap.get(ch) ?? 0) | 0;
-      r = Math.min(Math.max(0, r), Math.max(0, rowCount - 1));
-      c = Math.min(Math.max(0, c), Math.max(0, colCount - 1));
-
-      let rs = (rowSpan.get(ch) ?? 1) | 0;
-      let cs = (colSpan.get(ch) ?? 1) | 0;
-      rs = Math.min(Math.max(1, rs), Math.max(1, rowCount - r));
-      cs = Math.min(Math.max(1, cs), Math.max(1, colCount - c));
-
-      const x = xs[c] + c * this.colGap;
-      const y = ys[r] + r * this.rowGap;
-
-      const w = (xs[c + cs] - xs[c]) + (cs - 1) * this.colGap;
-      const h = (ys[r + rs] - ys[r]) + (rs - 1) * this.rowGap;
-
-      ch.arrange({ x, y, width: w, height: h });
-    }
-
-    this.drawDebug(xs, ys);
-  }
-
-  private drawDebug(xs: number[], ys: number[]) {
+  protected postArrange(xs: number[], ys: number[]) {
     const g = this.debugG;
     g.visible = this.debug;
     g.clear();
@@ -280,12 +95,12 @@ export class Grid extends UIElement {
     };
 
     for (const ch of this.children) {
-      let r = (rowMap.get(ch) ?? 0) | 0;
-      let c = (colMap.get(ch) ?? 0) | 0;
+      let r = (CoreGrid.getRow(ch) ?? 0) | 0;
+      let c = (CoreGrid.getCol(ch) ?? 0) | 0;
       r = Math.min(Math.max(0, r), this.rows.length - 1);
       c = Math.min(Math.max(0, c), this.cols.length - 1);
-      let rs = (rowSpan.get(ch) ?? 1) | 0;
-      let cs = (colSpan.get(ch) ?? 1) | 0;
+      let rs = (CoreGrid.getRowSpan(ch) ?? 1) | 0;
+      let cs = (CoreGrid.getColSpan(ch) ?? 1) | 0;
       rs = Math.min(Math.max(1, rs), this.rows.length - r);
       cs = Math.min(Math.max(1, cs), this.cols.length - c);
 

--- a/packages/runtime/src/elements/Image.ts
+++ b/packages/runtime/src/elements/Image.ts
@@ -1,25 +1,20 @@
-import { UIElement } from '../../../core/src/index.js';
-import type { Size, Rect } from '../../../core/src/index.js';
+import type { Rect } from '../../../core/src/index.js';
+import { Image as CoreImage } from '../../../core/src/index.js';
 import type { Renderer, RenderImage } from '../renderer.js';
 
-export class Image extends UIElement {
+export class Image extends CoreImage {
   sprite: RenderImage;
-  hAlign: 'Left'|'Center'|'Right' = 'Left';
-  vAlign: 'Top'|'Center'|'Bottom' = 'Top';
-  stretch: 'None'|'Fill'|'Uniform'|'UniformToFill' = 'Uniform';
-  private natW = 0;
-  private natH = 0;
 
   constructor(renderer: Renderer, tex?: any) {
     super();
     this.sprite = renderer.createImage(tex);
-    this.updateNaturalSize();
+    const size = this.sprite.getNaturalSize();
+    this.setNaturalSize(size.width, size.height);
   }
 
   private updateNaturalSize() {
     const size = this.sprite.getNaturalSize();
-    this.natW = Math.max(0, size.width);
-    this.natH = Math.max(0, size.height);
+    this.setNaturalSize(size.width, size.height);
   }
 
   setTexture(tex?: any) {
@@ -27,114 +22,9 @@ export class Image extends UIElement {
     this.updateNaturalSize();
   }
 
-  measure(avail: Size) {
-    const natW = this.natW || 0;
-    const natH = this.natH || 0;
-
-    const fallback = 180; // default so card doesn't collapse
-    const baseW = natW > 0 ? natW : fallback;
-    const baseH = natH > 0 ? natH : fallback;
-
-    if (this.prefW !== undefined && this.prefH !== undefined) {
-      const intrinsicW = this.prefW + this.margin.l + this.margin.r;
-      const intrinsicH = this.prefH + this.margin.t + this.margin.b;
-      this.desired = {
-        width: this.measureAxis('x', avail.width, intrinsicW),
-        height: this.measureAxis('y', avail.height, intrinsicH)
-      };
-      return;
-    }
-
-    if (this.prefW !== undefined && this.prefH === undefined) {
-      const h = baseH * (this.prefW / baseW);
-      const intrinsicW = this.prefW + this.margin.l + this.margin.r;
-      const intrinsicH = h + this.margin.t + this.margin.b;
-      this.desired = {
-        width: this.measureAxis('x', avail.width, intrinsicW),
-        height: this.measureAxis('y', avail.height, intrinsicH)
-      };
-      return;
-    }
-    if (this.prefH !== undefined && this.prefW === undefined) {
-      const w = baseW * (this.prefH / baseH);
-      const intrinsicW = w + this.margin.l + this.margin.r;
-      const intrinsicH = this.prefH + this.margin.t + this.margin.b;
-      this.desired = {
-        width: this.measureAxis('x', avail.width, intrinsicW),
-        height: this.measureAxis('y', avail.height, intrinsicH)
-      };
-      return;
-    }
-
-    const hasW = Number.isFinite(avail.width);
-    const hasH = Number.isFinite(avail.height);
-
-    let drawW = baseW;
-    let drawH = baseH;
-
-    if (this.stretch === 'None') {
-    } else if (this.stretch === 'Fill') {
-      drawW = hasW ? Math.min(avail.width, baseW) : baseW;
-      drawH = hasH ? Math.min(avail.height, baseH) : baseH;
-    } else if (this.stretch === 'Uniform') {
-      if (hasW && hasH) {
-        const s = Math.min(avail.width / baseW, avail.height / baseH, 1);
-        drawW = baseW * s; drawH = baseH * s;
-      } else if (hasW && !hasH) {
-        const s = Math.min(avail.width / baseW, 1);
-        drawW = baseW * s; drawH = baseH * s;
-      } else if (!hasW && hasH) {
-        const s = Math.min(avail.height / baseH, 1);
-        drawW = baseW * s; drawH = baseH * s;
-      } else {
-        drawW = baseW; drawH = baseH;
-      }
-    } else if (this.stretch === 'UniformToFill') {
-      if (hasW && hasH) {
-        const s = Math.min(Math.max(avail.width / baseW, avail.height / baseH), 1);
-        drawW = baseW * s; drawH = baseH * s;
-      } else if (hasW && !hasH) {
-        const s = Math.min(avail.width / baseW, 1);
-        drawW = baseW * s; drawH = baseH * s;
-      } else if (!hasW && hasH) {
-        const s = Math.min(avail.height / baseH, 1);
-        drawW = baseW * s; drawH = baseH * s;
-      } else {
-        drawW = baseW; drawH = baseH;
-      }
-    }
-
-    const intrinsicW = drawW + this.margin.l + this.margin.r;
-    const intrinsicH = drawH + this.margin.t + this.margin.b;
-    this.desired = {
-      width: this.measureAxis('x', avail.width, intrinsicW),
-      height: this.measureAxis('y', avail.height, intrinsicH)
-    };
-  }
-
   arrange(rect: Rect) {
-    const x0 = rect.x + this.margin.l, y0 = rect.y + this.margin.t;
-    const w = Math.max(0, rect.width - this.margin.l - this.margin.r);
-    const h = Math.max(0, rect.height - this.margin.t - this.margin.b);
-    this.final = { x: x0, y: y0, width: w, height: h };
-
-    const sw = this.natW || 1, sh = this.natH || 1;
-    let scaleX = 1, scaleY = 1, drawW = sw, drawH = sh;
-
-    switch (this.stretch) {
-      case 'None': { scaleX = scaleY = 1; drawW = sw; drawH = sh; break; }
-      case 'Fill': { scaleX = w / sw; scaleY = h / sh; drawW = w; drawH = h; break; }
-      case 'Uniform': { const s = Math.min(w / sw, h / sh); scaleX = scaleY = s; drawW = sw * s; drawH = sh * s; break; }
-      case 'UniformToFill': { const s = Math.max(w / sw, h / sh); scaleX = scaleY = s; drawW = sw * s; drawH = sh * s; break; }
-    }
-
-    let x = x0, y = y0;
-    if (this.hAlign === 'Center') x = x0 + (w - drawW) / 2;
-    else if (this.hAlign === 'Right') x = x0 + (w - drawW);
-    if (this.vAlign === 'Center') y = y0 + (h - drawH) / 2;
-    else if (this.vAlign === 'Bottom') y = y0 + (h - drawH);
-
-    this.sprite.setScale(scaleX, scaleY);
-    this.sprite.setPosition(x, y);
+    super.arrange(rect);
+    this.sprite.setScale(this.renderScaleX, this.renderScaleY);
+    this.sprite.setPosition(this.renderX, this.renderY);
   }
 }

--- a/packages/runtime/src/elements/Text.ts
+++ b/packages/runtime/src/elements/Text.ts
@@ -1,43 +1,22 @@
-import { UIElement } from '../../../core/src/index.js';
 import type { Size, Rect } from '../../../core/src/index.js';
+import { Text as CoreText } from '../../../core/src/index.js';
 import type { Renderer, RenderText } from '../renderer.js';
 
-export class Text extends UIElement {
+export class Text extends CoreText {
   text: RenderText;
-  hAlign: 'Left' | 'Center' | 'Right' = 'Left';
-  vAlign: 'Top' | 'Center' | 'Bottom' = 'Top';
 
   constructor(renderer: Renderer, content: string, style: { fill: string; fontSize: number }) {
-    super();
+    super(content, style);
     this.text = renderer.createText(content, style);
   }
 
-  measure(avail: Size) {
-    this.text.setWordWrap(Math.max(1, avail.width), 'left');
-    const b = this.text.getBounds();
-    const intrinsicW = b.width + this.margin.l + this.margin.r;
-    const intrinsicH = b.height + this.margin.t + this.margin.b;
-    this.desired = {
-      width: this.measureAxis('x', avail.width, intrinsicW),
-      height: this.measureAxis('y', avail.height, intrinsicH)
-    };
+  protected measureText(width: number, align: 'left' | 'center' | 'right'): Size {
+    this.text.setWordWrap(Math.max(1, width), align);
+    return this.text.getBounds();
   }
 
   arrange(rect: Rect) {
-    const x0 = rect.x + this.margin.l, y0 = rect.y + this.margin.t;
-    const w = Math.max(0, rect.width - this.margin.l - this.margin.r);
-    const h = Math.max(0, rect.height - this.margin.t - this.margin.b);
-    this.final = { x: x0, y: y0, width: w, height: h };
-
-    const align = this.hAlign === 'Center' ? 'center' : this.hAlign === 'Right' ? 'right' : 'left';
-    this.text.setWordWrap(Math.max(1, w), align);
-    const b = this.text.getBounds();
-
-    let x = x0, y = y0;
-    if (this.hAlign === 'Center') x = x0 + (w - b.width) / 2;
-    else if (this.hAlign === 'Right') x = x0 + (w - b.width);
-    if (this.vAlign === 'Center') y = y0 + (h - b.height) / 2;
-    else if (this.vAlign === 'Bottom') y = y0 + (h - b.height);
-    this.text.setPosition(x, y);
+    super.arrange(rect);
+    this.text.setPosition(this.renderX, this.renderY);
   }
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,5 +1,4 @@
 export * from './template.js';
-export { createDefaultRegistry, RuleRegistry } from '../../core/src/index.js';
 export * from './elements/BorderPanel.js';
 export * from './elements/Image.js';
 export * from './elements/Text.js';


### PR DESCRIPTION
## Summary
- extract renderer-independent logic from BorderPanel, Grid, Image and Text into core
- leave runtime adapters that connect core elements to the renderer
- update Grid parser and runtime exports

## Testing
- `pnpm -F @noxigui/core test`
- `pnpm -F @noxigui/runtime build`
- `pnpm -F @noxigui/parser build`
- `pnpm -F @noxigui/renderer-pixi build`


------
https://chatgpt.com/codex/tasks/task_e_68b0d9883118832a81d3c4a6f51819c9