### PR TITLE
feat(playground): add attribute completions

### DIFF
--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -198,8 +198,13 @@ export default function App() {
                 endColumn: position.column,
               });
 
-              const trimmed = textUntilPosition.trimStart();
-              if (!trimmed.startsWith('<')) {
+              const lastLt = textUntilPosition.lastIndexOf('<');
+              if (lastLt === -1) {
+                return { suggestions: [] };
+              }
+
+              const tagContent = textUntilPosition.slice(lastLt + 1);
+              if (tagContent.startsWith('/')) {
                 return { suggestions: [] };
               }
 
@@ -211,23 +216,27 @@ export default function App() {
                 endColumn: word.endColumn,
               };
 
-              const afterLt = trimmed.slice(1);
-              const hasSpace = afterLt.includes(' ');
+              const spaceIdx = tagContent.indexOf(' ');
+              const tagName =
+                spaceIdx === -1 ? tagContent : tagContent.slice(0, spaceIdx);
 
-              if (!hasSpace) {
+              if (spaceIdx === -1) {
                 const tagSuggestions: monacoEditor.languages.CompletionItem[] = [
                   {
                     label: 'Grid',
                     kind: monaco.languages.CompletionItemKind.Snippet,
                     insertText: '<Grid>\n\t$0\n</Grid>',
-                    insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+                    insertTextRules:
+                      monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
                     range,
                   },
                   {
                     label: 'Use Card',
                     kind: monaco.languages.CompletionItemKind.Snippet,
-                    insertText: '<Use Template="Card">\n\t<Slot Name="Media">\n\t\t$0\n\t</Slot>\n</Use>',
-                    insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+                    insertText:
+                      '<Use Template="Card">\n\t<Slot Name="Media">\n\t\t$0\n\t</Slot>\n</Use>',
+                    insertTextRules:
+                      monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
                     range,
                   },
                   {
@@ -241,15 +250,17 @@ export default function App() {
                 return { suggestions: tagSuggestions };
               }
 
-              const tagName = afterLt.split(/\s+/)[0];
               const attrs = elementAttributes[tagName] ?? [];
-              const attrSuggestions: monacoEditor.languages.CompletionItem[] = attrs.map(label => ({
-                label,
-                kind: monaco.languages.CompletionItemKind.Property,
-                insertText: `${label}="$0"`,
-                insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
-                range,
-              }));
+              const attrSuggestions: monacoEditor.languages.CompletionItem[] = attrs.map(
+                (label) => ({
+                  label,
+                  kind: monaco.languages.CompletionItemKind.Property,
+                  insertText: `${label}="$0"`,
+                  insertTextRules:
+                    monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+                  range,
+                })
+              );
 
               return { suggestions: attrSuggestions };
             },

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -1,6 +1,8 @@
 // App.tsx
 import React, { useEffect, useRef, useState } from 'react';
 import MonacoEditor from 'react-monaco-editor';
+import type * as monacoEditor from 'monaco-editor';
+import 'monaco-editor/esm/vs/basic-languages/xml/xml.contribution';
 import * as PIXI from 'pixi.js';
 import { RuntimeInstance } from '@noxigui/runtime';
 import { createPixiRenderer } from '@noxigui/renderer-pixi';
@@ -174,11 +176,91 @@ export default function App() {
         onChange={setCode}
         height="100%"
         width="50%"
+        editorDidMount={(_editor: monacoEditor.editor.IStandaloneCodeEditor, monaco: typeof monacoEditor) => {
+          const elementAttributes: Record<string, string[]> = {
+            Grid: ['Margin', 'RowGap', 'ColumnGap', 'Row', 'Column'],
+            Use: ['Template', 'Title', 'TitleSize', 'Grid.Row', 'Grid.Column'],
+            Slot: ['Name'],
+            Image: ['Source', 'Stretch', 'HorizontalAlignment', 'VerticalAlignment'],
+            Border: ['Padding', 'Background', 'ClipToBounds'],
+            TextBlock: ['Text', 'FontSize', 'Foreground'],
+            RowDefinition: ['Height'],
+            ColumnDefinition: ['Width'],
+          };
+
+          monaco.languages.registerCompletionItemProvider('xml', {
+            triggerCharacters: ['<', ' ', '.'],
+            provideCompletionItems: (model, position) => {
+              const textUntilPosition = model.getValueInRange({
+                startLineNumber: position.lineNumber,
+                startColumn: 1,
+                endLineNumber: position.lineNumber,
+                endColumn: position.column,
+              });
+
+              const trimmed = textUntilPosition.trimStart();
+              if (!trimmed.startsWith('<')) {
+                return { suggestions: [] };
+              }
+
+              const word = model.getWordUntilPosition(position);
+              const range: monacoEditor.IRange = {
+                startLineNumber: position.lineNumber,
+                endLineNumber: position.lineNumber,
+                startColumn: word.startColumn,
+                endColumn: word.endColumn,
+              };
+
+              const afterLt = trimmed.slice(1);
+              const hasSpace = afterLt.includes(' ');
+
+              if (!hasSpace) {
+                const tagSuggestions: monacoEditor.languages.CompletionItem[] = [
+                  {
+                    label: 'Grid',
+                    kind: monaco.languages.CompletionItemKind.Snippet,
+                    insertText: '<Grid>\n\t$0\n</Grid>',
+                    insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+                    range,
+                  },
+                  {
+                    label: 'Use Card',
+                    kind: monaco.languages.CompletionItemKind.Snippet,
+                    insertText: '<Use Template="Card">\n\t<Slot Name="Media">\n\t\t$0\n\t</Slot>\n</Use>',
+                    insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+                    range,
+                  },
+                  {
+                    label: 'RowDefinition',
+                    kind: monaco.languages.CompletionItemKind.Snippet,
+                    insertText: '<RowDefinition Height="Auto" />',
+                    range,
+                  },
+                ];
+
+                return { suggestions: tagSuggestions };
+              }
+
+              const tagName = afterLt.split(/\s+/)[0];
+              const attrs = elementAttributes[tagName] ?? [];
+              const attrSuggestions: monacoEditor.languages.CompletionItem[] = attrs.map(label => ({
+                label,
+                kind: monaco.languages.CompletionItemKind.Property,
+                insertText: `${label}="$0"`,
+                insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+                range,
+              }));
+
+              return { suggestions: attrSuggestions };
+            },
+          });
+        }}
         options={{
           minimap: { enabled: false },
           fontSize: 14,
           scrollBeyondLastLine: false,
           automaticLayout: true,
+          suggestOnTriggerCharacters: true,
         }}
       />
       <div


### PR DESCRIPTION
## Summary
- support XAML attribute completions in the Monaco playground editor
- trigger suggestions on tag starts and inside tag bodies
- import XML language contribution and enable trigger-character suggestions to restore highlighting and completions

## Testing
- `pnpm -F @noxigui/runtime build`
- `pnpm -F @noxigui/renderer-pixi build`
- `pnpm -F @noxigui/playground build`


------
https://chatgpt.com/codex/tasks/task_e_68b0da47ecc4832ab096dddf3ead8ec8