### PR TITLE
refactor(parser): use renderer containers

### DIFF
--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -9,8 +9,8 @@
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "pixi.js": "^7.4.3",
-    "@noxigui/core": "file:../core"
+    "@noxigui/core": "file:../core",
+    "@noxigui/runtime-core": "file:../runtime-core"
   },
   "devDependencies": {
     "typescript": "~5.8.3"

--- a/packages/parser/src/Parser.ts
+++ b/packages/parser/src/Parser.ts
@@ -1,10 +1,9 @@
-import * as PIXI from 'pixi.js';
 import { UIElement } from '@noxigui/core';
 import { parsers as elementParsers } from './parsers/index.js';
-import type { Renderer } from '@noxigui/core';
+import type { Renderer, RenderContainer } from '@noxigui/core';
 
 /**
- * Parses NoxiGUI XML markup into UI elements and a PIXI display tree.
+ * Parses NoxiGUI XML markup into UI elements and a renderer display tree.
  */
 export class Parser {
   /**
@@ -30,12 +29,12 @@ export class Parser {
   }
 
   /**
-   * Parse an XML document into UI elements and assemble the PIXI container tree.
+   * Parse an XML document into UI elements and assemble the renderer container tree.
    *
    * @param xml - XML markup starting with a `<Grid>` root element.
-   * @returns Object containing the root UI element and the PIXI container tree.
-   */
-  parse(xml: string) {
+   * @returns Object containing the root UI element and the renderer container tree.
+  */
+  parse(xml: string): { root: UIElement; container: RenderContainer } {
     const dom = new DOMParser().parseFromString(xml, 'application/xml');
     const rootEl = dom.documentElement;
     if (rootEl.tagName !== 'Grid') throw new Error('Root must be <Grid>');
@@ -43,10 +42,10 @@ export class Parser {
     const root = this.parseElement(rootEl);
     if (!root) throw new Error('Failed to parse root element');
 
-    const container = new PIXI.Container();
-    container.sortableChildren = true;
+    const container = this.renderer.createContainer();
+    container.setSortableChildren(true);
 
-    const collect = (into: PIXI.Container, u: UIElement) => {
+    const collect = (into: RenderContainer, u: UIElement) => {
       for (const p of this.parsers) {
         if (p.collect && p.collect(into, u, collect)) return;
       }

--- a/packages/parser/src/parsers/BorderParser.ts
+++ b/packages/parser/src/parsers/BorderParser.ts
@@ -1,9 +1,7 @@
-import { BorderPanel } from '../../../runtime-core/src/elements/BorderPanel.js';
-import { applyGridAttachedProps, parseSizeAttrs, parseColor, parseMargin, applyMargin } from '../../../runtime-core/src/helpers.js';
+import { BorderPanel, applyGridAttachedProps, parseSizeAttrs, parseColor, parseMargin, applyMargin } from '@noxigui/runtime-core';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
-import type { UIElement } from '@noxigui/core';
-import type * as PIXI from 'pixi.js';
+import type { UIElement, RenderContainer } from '@noxigui/core';
 
 /** Parser for `<Border>` elements. */
 export class BorderParser implements ElementParser {
@@ -22,7 +20,7 @@ export class BorderParser implements ElementParser {
     return panel;
   }
 
-  collect(into: PIXI.Container, el: UIElement, collect: (into: PIXI.Container, el: UIElement) => void) {
+  collect(into: RenderContainer, el: UIElement, collect: (into: RenderContainer, el: UIElement) => void) {
     if (el instanceof BorderPanel) {
       const group = el.container.getDisplayObject();
       el.container.setSortableChildren(true);

--- a/packages/parser/src/parsers/ContentPresenterParser.ts
+++ b/packages/parser/src/parsers/ContentPresenterParser.ts
@@ -1,9 +1,7 @@
-import { ContentPresenter } from '../../../runtime-core/src/index.js';
-import { applyGridAttachedProps, applyMargin } from '../../../runtime-core/src/helpers.js';
+import { ContentPresenter, applyGridAttachedProps, applyMargin } from '@noxigui/runtime-core';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
-import type { UIElement } from '@noxigui/core';
-import type * as PIXI from 'pixi.js';
+import type { UIElement, RenderContainer } from '@noxigui/core';
 
 /** Parser for `<ContentPresenter>` elements. */
 export class ContentPresenterParser implements ElementParser {
@@ -15,7 +13,7 @@ export class ContentPresenterParser implements ElementParser {
     return cp;
   }
 
-  collect(into: PIXI.Container, el: UIElement, collect: (into: PIXI.Container, el: UIElement) => void) {
+  collect(into: RenderContainer, el: UIElement, collect: (into: RenderContainer, el: UIElement) => void) {
     if (el instanceof ContentPresenter && (el as any).child) {
       collect(into, (el as any).child);
       return true;

--- a/packages/parser/src/parsers/ElementParser.ts
+++ b/packages/parser/src/parsers/ElementParser.ts
@@ -1,6 +1,5 @@
-import type { UIElement } from '@noxigui/core';
+import type { UIElement, RenderContainer } from '@noxigui/core';
 import type { Parser } from '../Parser.js';
-import type * as PIXI from 'pixi.js';
 
 /**
  * Converts DOM nodes into runtime UI elements.
@@ -20,12 +19,12 @@ export interface ElementParser {
      */
   parse(node: Element, p: Parser): UIElement | null;
   /**
-     * Optionally attach UI elements to the PIXI display tree.
+     * Optionally attach UI elements to the renderer display tree.
      *
      * @param into - Container to attach to.
      * @param el - Parsed UI element.
      * @param collect - Recursive helper to collect children.
      * @returns `true` if the element was collected.
      */
-  collect?(into: PIXI.Container, el: UIElement, collect: (into: PIXI.Container, el: UIElement) => void): boolean | void;
+  collect?(into: RenderContainer, el: UIElement, collect: (into: RenderContainer, el: UIElement) => void): boolean | void;
 }

--- a/packages/parser/src/parsers/GridParser.ts
+++ b/packages/parser/src/parsers/GridParser.ts
@@ -1,10 +1,8 @@
-import { Grid } from '../../../runtime-core/src/elements/Grid.js';
+import { Grid, applyGridAttachedProps, parseLen, applyMargin } from '@noxigui/runtime-core';
 import { Row, Col } from '@noxigui/core';
-import { applyGridAttachedProps, parseLen, applyMargin } from '../../../runtime-core/src/helpers.js';
+import type { UIElement, RenderContainer } from '@noxigui/core';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
-import type { UIElement } from '@noxigui/core';
-import type * as PIXI from 'pixi.js';
 
 /** Parser for `<Grid>` elements. */
 export class GridParser implements ElementParser {
@@ -36,12 +34,12 @@ export class GridParser implements ElementParser {
     return g;
   }
 
-  collect(into: PIXI.Container, el: UIElement, collect: (into: PIXI.Container, el: UIElement) => void) {
+  collect(into: RenderContainer, el: UIElement, collect: (into: RenderContainer, el: UIElement) => void) {
     if (el instanceof Grid) {
       for (const ch of el.children) collect(into, ch);
       el.debugG.zIndex = 100000;
-      if (el.debugG.parent !== into) {
-        el.debugG.parent?.removeChild(el.debugG);
+      if ((el.debugG as any).parent !== into) {
+        (el.debugG as any).parent?.removeChild(el.debugG);
         into.addChild(el.debugG);
       }
       return true;

--- a/packages/parser/src/parsers/ImageParser.ts
+++ b/packages/parser/src/parsers/ImageParser.ts
@@ -1,17 +1,15 @@
-import * as PIXI from 'pixi.js';
-import { Image } from '../../../runtime-core/src/elements/Image.js';
-import { applyGridAttachedProps, parseSizeAttrs, applyMargin, applyAlignment } from '../../../runtime-core/src/helpers.js';
+import { Image, applyGridAttachedProps, parseSizeAttrs, applyMargin, applyAlignment } from '@noxigui/runtime-core';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
-import type { UIElement } from '@noxigui/core';
+import type { UIElement, RenderContainer } from '@noxigui/core';
 
 /** Parser for `<Image>` elements. */
 export class ImageParser implements ElementParser {
   test(node: Element): boolean { return node.tagName === 'Image'; }
   parse(node: Element, p: Parser) {
     const key = node.getAttribute('Source') ?? '';
-    let tex: PIXI.Texture | undefined;
-    try { tex = PIXI.Assets.get(key) as PIXI.Texture | undefined; } catch {}
+    let tex: any;
+    try { tex = (globalThis as any).PIXI?.Assets?.get(key); } catch {}
     const img = new Image(p.renderer, tex);
     parseSizeAttrs(node, img);
     applyMargin(node, img);
@@ -24,7 +22,7 @@ export class ImageParser implements ElementParser {
     return img;
   }
 
-  collect(into: PIXI.Container, el: UIElement) {
+  collect(into: RenderContainer, el: UIElement) {
     if (el instanceof Image) {
       into.addChild(el.sprite.getDisplayObject());
       return true;

--- a/packages/parser/src/parsers/ResourcesParser.ts
+++ b/packages/parser/src/parsers/ResourcesParser.ts
@@ -1,4 +1,4 @@
-import { registerTemplate } from '../../../runtime-core/src/template.js';
+import { registerTemplate } from '@noxigui/runtime-core';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
 

--- a/packages/parser/src/parsers/TextBlockParser.ts
+++ b/packages/parser/src/parsers/TextBlockParser.ts
@@ -1,9 +1,7 @@
-import { Text } from '../../../runtime-core/src/elements/Text.js';
-import { applyGridAttachedProps, parseSizeAttrs, applyMargin, applyAlignment } from '../../../runtime-core/src/helpers.js';
+import { Text, applyGridAttachedProps, parseSizeAttrs, applyMargin, applyAlignment } from '@noxigui/runtime-core';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
-import type { UIElement } from '@noxigui/core';
-import type * as PIXI from 'pixi.js';
+import type { UIElement, RenderContainer } from '@noxigui/core';
 
 /** Parser for `<TextBlock>` elements. */
 export class TextBlockParser implements ElementParser {
@@ -20,7 +18,7 @@ export class TextBlockParser implements ElementParser {
     return leaf;
   }
 
-  collect(into: PIXI.Container, el: UIElement) {
+  collect(into: RenderContainer, el: UIElement) {
     if (el instanceof Text) {
       into.addChild(el.text.getDisplayObject());
       return true;

--- a/packages/parser/src/parsers/UseParser.ts
+++ b/packages/parser/src/parsers/UseParser.ts
@@ -1,4 +1,4 @@
-import { instantiateTemplate } from '../../../runtime-core/src/template.js';
+import { instantiateTemplate } from '@noxigui/runtime-core';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,9 +22,9 @@ importers:
       '@noxigui/core':
         specifier: file:../core
         version: link:../core
-      pixi.js:
-        specifier: ^7.4.3
-        version: 7.4.3
+      '@noxigui/runtime-core':
+        specifier: file:../runtime-core
+        version: link:../runtime-core
     devDependencies:
       typescript:
         specifier: ~5.8.3


### PR DESCRIPTION
## Summary
- use renderer-created containers and RenderContainer type throughout parser
- swap pixi and runtime-core internal imports for @noxigui/runtime-core
- adjust element parser types for renderer-agnostic collect

## Testing
- `pnpm -F @noxigui/parser build`


------
https://chatgpt.com/codex/tasks/task_e_68b0e5084868832a8543be2d8f6cb75c