### PR TITLE
feat: expose parser and runtime core packages

### DIFF
--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -2,9 +2,14 @@
   "name": "@noxigui/parser",
   "version": "0.1.0",
   "type": "module",
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
-  "exports": "./dist/src/index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },

--- a/packages/parser/src/parsers/BorderParser.ts
+++ b/packages/parser/src/parsers/BorderParser.ts
@@ -1,4 +1,11 @@
-import { BorderPanel, applyGridAttachedProps, parseSizeAttrs, parseColor, parseMargin, applyMargin } from '@noxigui/runtime-core';
+import {
+  BorderPanel,
+  applyGridAttachedProps,
+  parseSizeAttrs,
+  parseColor,
+  parseMargin,
+  applyMargin,
+} from '@noxigui/runtime-core';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
 import type { UIElement, RenderContainer } from '@noxigui/core';

--- a/packages/runtime-core/package.json
+++ b/packages/runtime-core/package.json
@@ -2,9 +2,14 @@
   "name": "@noxigui/runtime-core",
   "version": "0.1.0",
   "type": "module",
-  "main": "dist/runtime-core/src/index.js",
-  "types": "dist/runtime-core/src/index.d.ts",
-  "exports": "./dist/runtime-core/src/index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },

--- a/packages/runtime-core/src/runtime.ts
+++ b/packages/runtime-core/src/runtime.ts
@@ -1,4 +1,4 @@
-import { Parser } from '../../parser/src/Parser.js';
+import { Parser } from '@noxigui/parser';
 import { Grid } from './elements/Grid.js';
 import { UIElement } from '@noxigui/core';
 import type { Size, Renderer } from '@noxigui/core';
@@ -21,7 +21,7 @@ export const RuntimeInstance = {
       root.arrange({ x: 0, y: 0, width: size.width, height: size.height });
     };
 
-    const destroy = () => container.destroy({ children: true });
+    const destroy = () => container.getDisplayObject().destroy({ children: true });
 
     return { container, layout, destroy, setGridDebug };
   }


### PR DESCRIPTION
## Summary
- expose parser entry point through package.json exports
- expose runtime-core elements and use parser via package import
- clean up runtime container teardown and tidy BorderParser import

## Testing
- `pnpm -F @noxigui/runtime-core build`
- `pnpm -F @noxigui/parser build`


------
https://chatgpt.com/codex/tasks/task_e_68b0e6bc4f00832ab925eba0056c679f