### PR TITLE
refactor: extract runtime package

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This repository is a monorepo containing:
 
 - `@noxigui/core` – foundational types, layout engine and UI elements.
 - `@noxigui/parser` – XML parser that produces runtime UI trees.
-- `@noxigui/runtime-core` – minimal runtime wiring parser output to a renderer.
+- `@noxigui/runtime-core` – core runtime elements and helpers.
+- `@noxigui/runtime` – bootstraps parser output to a renderer.
 - `@noxigui/renderer-pixi` – PIXI-based renderer implementation.
 - `@noxigui/playground` – a Vite playground for experimenting with the runtime.
 

--- a/packages/parser/src/Parser.ts
+++ b/packages/parser/src/Parser.ts
@@ -1,6 +1,5 @@
-import { UIElement } from '@noxigui/core';
+import { UIElement, type Renderer, type RenderContainer } from '@noxigui/runtime-core';
 import { parsers as elementParsers } from './parsers/index.js';
-import type { Renderer, RenderContainer } from '@noxigui/core';
 
 /**
  * Parses NoxiGUI XML markup into UI elements and a renderer display tree.

--- a/packages/parser/src/parsers/BorderParser.ts
+++ b/packages/parser/src/parsers/BorderParser.ts
@@ -8,7 +8,7 @@ import {
 } from '@noxigui/runtime-core';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
-import type { UIElement, RenderContainer } from '@noxigui/core';
+import type { UIElement, RenderContainer } from '@noxigui/runtime-core';
 
 /** Parser for `<Border>` elements. */
 export class BorderParser implements ElementParser {

--- a/packages/parser/src/parsers/ContentPresenterParser.ts
+++ b/packages/parser/src/parsers/ContentPresenterParser.ts
@@ -1,7 +1,7 @@
 import { ContentPresenter, applyGridAttachedProps, applyMargin } from '@noxigui/runtime-core';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
-import type { UIElement, RenderContainer } from '@noxigui/core';
+import type { UIElement, RenderContainer } from '@noxigui/runtime-core';
 
 /** Parser for `<ContentPresenter>` elements. */
 export class ContentPresenterParser implements ElementParser {

--- a/packages/parser/src/parsers/ElementParser.ts
+++ b/packages/parser/src/parsers/ElementParser.ts
@@ -1,4 +1,4 @@
-import type { UIElement, RenderContainer } from '@noxigui/core';
+import type { UIElement, RenderContainer } from '@noxigui/runtime-core';
 import type { Parser } from '../Parser.js';
 
 /**

--- a/packages/parser/src/parsers/GridParser.ts
+++ b/packages/parser/src/parsers/GridParser.ts
@@ -1,6 +1,5 @@
-import { Grid, applyGridAttachedProps, parseLen, applyMargin } from '@noxigui/runtime-core';
-import { Row, Col } from '@noxigui/core';
-import type { UIElement, RenderContainer } from '@noxigui/core';
+import { Grid, Row, Col, applyGridAttachedProps, parseLen, applyMargin } from '@noxigui/runtime-core';
+import type { UIElement, RenderContainer } from '@noxigui/runtime-core';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
 

--- a/packages/parser/src/parsers/ImageParser.ts
+++ b/packages/parser/src/parsers/ImageParser.ts
@@ -1,7 +1,7 @@
 import { Image, applyGridAttachedProps, parseSizeAttrs, applyMargin, applyAlignment } from '@noxigui/runtime-core';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
-import type { UIElement, RenderContainer } from '@noxigui/core';
+import type { UIElement, RenderContainer } from '@noxigui/runtime-core';
 
 /** Parser for `<Image>` elements. */
 export class ImageParser implements ElementParser {

--- a/packages/parser/src/parsers/TextBlockParser.ts
+++ b/packages/parser/src/parsers/TextBlockParser.ts
@@ -1,7 +1,7 @@
 import { Text, applyGridAttachedProps, parseSizeAttrs, applyMargin, applyAlignment } from '@noxigui/runtime-core';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
-import type { UIElement, RenderContainer } from '@noxigui/core';
+import type { UIElement, RenderContainer } from '@noxigui/runtime-core';
 
 /** Parser for `<TextBlock>` elements. */
 export class TextBlockParser implements ElementParser {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@noxigui/runtime-core": "file:../runtime-core",
+    "@noxigui/runtime": "file:../runtime",
     "@noxigui/renderer-pixi": "workspace:*",
     "pixi.js": "^7.4.3",
     "react": "^19.1.0",

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import MonacoEditor from 'react-monaco-editor';
 import * as PIXI from 'pixi.js';
-import { RuntimeInstance } from '@noxigui/runtime-core';
+import { RuntimeInstance } from '@noxigui/runtime';
 import { createPixiRenderer } from '@noxigui/renderer-pixi';
 
 const initialSchema = `

--- a/packages/runtime-core/package.json
+++ b/packages/runtime-core/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "pixi.js": "^7.4.3",
-    "@noxigui/parser": "file:../parser",
     "@noxigui/core": "file:../core"
   },
   "devDependencies": {

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -5,5 +5,5 @@ export * from './elements/Text.js';
 export * from './elements/Grid.js';
 export * from './elements/ContentPresenter.js';
 export * from './helpers.js';
-export type { Renderer, RenderImage, RenderText, RenderGraphics, RenderContainer } from '@noxigui/core';
-export { RuntimeInstance } from './runtime.js';
+export type { Renderer, RenderImage, RenderText, RenderGraphics, RenderContainer, Size } from '@noxigui/core';
+export { UIElement } from '@noxigui/core';

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@noxigui/parser",
+  "name": "@noxigui/runtime",
   "version": "0.1.0",
   "type": "module",
   "main": "dist/index.js",
@@ -14,6 +14,7 @@
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
+    "@noxigui/parser": "file:../parser",
     "@noxigui/runtime-core": "file:../runtime-core"
   },
   "devDependencies": {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,0 +1,1 @@
+export { RuntimeInstance } from './runtime.js';

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -1,7 +1,5 @@
 import { Parser } from '@noxigui/parser';
-import { Grid } from './elements/Grid.js';
-import { UIElement } from '@noxigui/core';
-import type { Size, Renderer } from '@noxigui/core';
+import { Grid, UIElement, type Size, type Renderer } from '@noxigui/runtime-core';
 
 export const RuntimeInstance = {
   create(xml: string, renderer: Renderer) {

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "allowImportingTsExtensions": false,
+    "erasableSyntaxOnly": false
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,9 +19,6 @@ importers:
 
   packages/parser:
     dependencies:
-      '@noxigui/core':
-        specifier: file:../core
-        version: link:../core
       '@noxigui/runtime-core':
         specifier: file:../runtime-core
         version: link:../runtime-core
@@ -35,9 +32,9 @@ importers:
       '@noxigui/renderer-pixi':
         specifier: workspace:*
         version: link:../renderer-pixi
-      '@noxigui/runtime-core':
-        specifier: file:../runtime-core
-        version: link:../runtime-core
+      '@noxigui/runtime':
+        specifier: file:../runtime
+        version: link:../runtime
       pixi.js:
         specifier: ^7.4.3
         version: 7.4.3
@@ -79,14 +76,24 @@ importers:
         specifier: ^7.4.0
         version: 7.4.3
 
+  packages/runtime:
+    dependencies:
+      '@noxigui/parser':
+        specifier: file:../parser
+        version: link:../parser
+      '@noxigui/runtime-core':
+        specifier: file:../runtime-core
+        version: link:../runtime-core
+    devDependencies:
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+
   packages/runtime-core:
     dependencies:
       '@noxigui/core':
         specifier: file:../core
         version: link:../core
-      '@noxigui/parser':
-        specifier: file:../parser
-        version: link:../parser
       pixi.js:
         specifier: ^7.4.3
         version: 7.4.3


### PR DESCRIPTION
## Summary
- add `@noxigui/runtime` package combining parser and runtime-core
- remove parser dependency from `runtime-core`
- update parser and playground to new runtime entry

## Testing
- `pnpm build`
- `pnpm -F @noxigui/core test`


------
https://chatgpt.com/codex/tasks/task_e_68b1036c2154832ab87e413a7840cbf5