### PR TITLE
feat: add texture retrieval

### DIFF
--- a/packages/parser/src/parsers/ImageParser.ts
+++ b/packages/parser/src/parsers/ImageParser.ts
@@ -1,4 +1,3 @@
-import * as PIXI from 'pixi.js';
 import { Image } from '../../../runtime/src/elements/Image.js';
 import { applyGridAttachedProps, parseSizeAttrs, applyMargin, applyAlignment } from '../../../runtime/src/helpers.js';
 import type { ElementParser } from './ElementParser.js';
@@ -10,8 +9,7 @@ export class ImageParser implements ElementParser {
   test(node: Element): boolean { return node.tagName === 'Image'; }
   parse(node: Element, p: Parser) {
     const key = node.getAttribute('Source') ?? '';
-    let tex: PIXI.Texture | undefined;
-    try { tex = PIXI.Assets.get(key) as PIXI.Texture | undefined; } catch {}
+    const tex = p.renderer.getTexture(key);
     const img = new Image(p.renderer, tex);
     parseSizeAttrs(node, img);
     applyMargin(node, img);
@@ -24,7 +22,7 @@ export class ImageParser implements ElementParser {
     return img;
   }
 
-  collect(into: PIXI.Container, el: UIElement) {
+  collect(into: any, el: UIElement) {
     if (el instanceof Image) {
       into.addChild(el.sprite.getDisplayObject());
       return true;

--- a/packages/renderer-pixi/src/index.ts
+++ b/packages/renderer-pixi/src/index.ts
@@ -9,12 +9,12 @@ import type {
 
 class PixiRenderImage implements RenderImage {
   sprite: PIXI.Sprite;
-  constructor(tex?: PIXI.Texture) {
-    this.sprite = new PIXI.Sprite(tex ?? PIXI.Texture.WHITE);
+  constructor(tex?: unknown) {
+    this.sprite = new PIXI.Sprite((tex as PIXI.Texture | undefined) ?? PIXI.Texture.WHITE);
     this.sprite.anchor.set(0, 0);
   }
-  setTexture(tex?: PIXI.Texture) {
-    this.sprite.texture = tex ?? PIXI.Texture.WHITE;
+  setTexture(tex?: unknown) {
+    this.sprite.texture = (tex as PIXI.Texture | undefined) ?? PIXI.Texture.WHITE;
   }
   setPosition(x: number, y: number) {
     this.sprite.x = x;
@@ -117,7 +117,14 @@ class PixiRenderContainer implements RenderContainer {
 
 export function createPixiRenderer(): Renderer {
   return {
-    createImage(tex?: PIXI.Texture) {
+    getTexture(key: string) {
+      try {
+        return PIXI.Assets.get(key);
+      } catch {
+        return PIXI.Texture.from(key);
+      }
+    },
+    createImage(tex?: unknown) {
       return new PixiRenderImage(tex);
     },
     createText(content: string, style: { fill: string; fontSize: number }) {

--- a/packages/runtime/src/elements/Image.ts
+++ b/packages/runtime/src/elements/Image.ts
@@ -10,7 +10,7 @@ export class Image extends UIElement {
   private natW = 0;
   private natH = 0;
 
-  constructor(renderer: Renderer, tex?: any) {
+  constructor(renderer: Renderer, tex?: unknown) {
     super();
     this.sprite = renderer.createImage(tex);
     this.updateNaturalSize();
@@ -22,7 +22,7 @@ export class Image extends UIElement {
     this.natH = Math.max(0, size.height);
   }
 
-  setTexture(tex?: any) {
+  setTexture(tex?: unknown) {
     this.sprite.setTexture(tex);
     this.updateNaturalSize();
   }

--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -1,5 +1,5 @@
 export interface RenderImage {
-  setTexture(tex?: any): void;
+  setTexture(tex?: unknown): void;
   setPosition(x: number, y: number): void;
   setScale(x: number, y: number): void;
   getNaturalSize(): { width: number; height: number };
@@ -32,7 +32,8 @@ export interface RenderContainer {
 }
 
 export interface Renderer {
-  createImage(tex?: any): RenderImage;
+  getTexture(key: string): unknown;
+  createImage(tex?: unknown): RenderImage;
   createText(text: string, style: { fill: string; fontSize: number }): RenderText;
   createGraphics(): RenderGraphics;
   createContainer(): RenderContainer;


### PR DESCRIPTION
## Summary
- add generic getTexture to Renderer interface
- load textures through renderer in ImageParser and Image
- implement getTexture in Pixi renderer with Assets fallback
- drop direct pixi import from ImageParser

## Testing
- `pnpm install`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b110d4d68c832aa74aeb5c7cc5d616