### PR TITLE
refactor parser to use renderer containers

### DIFF
--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -1,6 +1,6 @@
 # @noxigui/parser
 
-Parses NoxiGUI XML markup into runtime UI elements and a PIXI display tree.
+Parses NoxiGUI XML markup into runtime UI elements and a renderer display tree.
 
 ## Installation
 

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -8,9 +8,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },
-  "dependencies": {
-    "pixi.js": "^7.4.3"
-  },
+  "dependencies": {},
   "devDependencies": {
     "typescript": "~5.8.3"
   }

--- a/packages/parser/src/Parser.ts
+++ b/packages/parser/src/Parser.ts
@@ -1,7 +1,6 @@
-import * as PIXI from 'pixi.js';
 import { UIElement } from '../../runtime/src/core.js';
 import { parsers as elementParsers } from './parsers/index.js';
-import type { Renderer } from '../../runtime/src/renderer.js';
+import type { Renderer, RenderContainer } from '../../runtime/src/renderer.js';
 
 /**
  * Parses NoxiGUI XML markup into UI elements and a PIXI display tree.
@@ -30,10 +29,10 @@ export class Parser {
   }
 
   /**
-   * Parse an XML document into UI elements and assemble the PIXI container tree.
+   * Parse an XML document into UI elements and assemble the renderer's container tree.
    *
    * @param xml - XML markup starting with a `<Grid>` root element.
-   * @returns Object containing the root UI element and the PIXI container tree.
+   * @returns Object containing the root UI element and the root render container.
    */
   parse(xml: string) {
     const dom = new DOMParser().parseFromString(xml, 'application/xml');
@@ -43,10 +42,10 @@ export class Parser {
     const root = this.parseElement(rootEl);
     if (!root) throw new Error('Failed to parse root element');
 
-    const container = new PIXI.Container();
-    container.sortableChildren = true;
+    const container = this.renderer.createContainer();
+    container.setSortableChildren(true);
 
-    const collect = (into: PIXI.Container, u: UIElement) => {
+    const collect = (into: RenderContainer, u: UIElement) => {
       for (const p of this.parsers) {
         if (p.collect && p.collect(into, u, collect)) return;
       }

--- a/packages/parser/src/parsers/BorderParser.ts
+++ b/packages/parser/src/parsers/BorderParser.ts
@@ -3,7 +3,7 @@ import { applyGridAttachedProps, parseSizeAttrs, parseColor, parseMargin, applyM
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
 import type { UIElement } from '../../../runtime/src/core.js';
-import type * as PIXI from 'pixi.js';
+import type { RenderContainer } from '../../../runtime/src/renderer.js';
 
 /** Parser for `<Border>` elements. */
 export class BorderParser implements ElementParser {
@@ -22,11 +22,11 @@ export class BorderParser implements ElementParser {
     return panel;
   }
 
-  collect(into: PIXI.Container, el: UIElement, collect: (into: PIXI.Container, el: UIElement) => void) {
+  collect(into: RenderContainer, el: UIElement, collect: (into: RenderContainer, el: UIElement) => void) {
     if (el instanceof BorderPanel) {
-      const group = el.container.getDisplayObject();
-      el.container.setSortableChildren(true);
-      into.addChild(group);
+      const group = el.container;
+      group.setSortableChildren(true);
+      into.addChild(group.getDisplayObject());
       if (el.child) collect(group, el.child);
       return true;
     }

--- a/packages/parser/src/parsers/ContentPresenterParser.ts
+++ b/packages/parser/src/parsers/ContentPresenterParser.ts
@@ -3,7 +3,7 @@ import { applyGridAttachedProps, applyMargin } from '../../../runtime/src/helper
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
 import type { UIElement } from '../../../runtime/src/core.js';
-import type * as PIXI from 'pixi.js';
+import type { RenderContainer } from '../../../runtime/src/renderer.js';
 
 /** Parser for `<ContentPresenter>` elements. */
 export class ContentPresenterParser implements ElementParser {
@@ -15,7 +15,7 @@ export class ContentPresenterParser implements ElementParser {
     return cp;
   }
 
-  collect(into: PIXI.Container, el: UIElement, collect: (into: PIXI.Container, el: UIElement) => void) {
+  collect(into: RenderContainer, el: UIElement, collect: (into: RenderContainer, el: UIElement) => void) {
     if (el instanceof ContentPresenter && (el as any).child) {
       collect(into, (el as any).child);
       return true;

--- a/packages/parser/src/parsers/ElementParser.ts
+++ b/packages/parser/src/parsers/ElementParser.ts
@@ -1,6 +1,6 @@
 import type { UIElement } from '../../../runtime/src/core.js';
 import type { Parser } from '../Parser.js';
-import type * as PIXI from 'pixi.js';
+import type { RenderContainer } from '../../../runtime/src/renderer.js';
 
 /**
  * Converts DOM nodes into runtime UI elements.
@@ -20,12 +20,12 @@ export interface ElementParser {
      */
   parse(node: Element, p: Parser): UIElement | null;
   /**
-     * Optionally attach UI elements to the PIXI display tree.
+     * Optionally attach UI elements to the renderer display tree.
      *
      * @param into - Container to attach to.
      * @param el - Parsed UI element.
      * @param collect - Recursive helper to collect children.
      * @returns `true` if the element was collected.
      */
-  collect?(into: PIXI.Container, el: UIElement, collect: (into: PIXI.Container, el: UIElement) => void): boolean | void;
+  collect?(into: RenderContainer, el: UIElement, collect: (into: RenderContainer, el: UIElement) => void): boolean | void;
 }

--- a/packages/parser/src/parsers/GridParser.ts
+++ b/packages/parser/src/parsers/GridParser.ts
@@ -3,7 +3,7 @@ import { applyGridAttachedProps, parseLen, applyMargin } from '../../../runtime/
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
 import type { UIElement } from '../../../runtime/src/core.js';
-import type * as PIXI from 'pixi.js';
+import type { RenderContainer } from '../../../runtime/src/renderer.js';
 
 /** Parser for `<Grid>` elements. */
 export class GridParser implements ElementParser {
@@ -35,12 +35,14 @@ export class GridParser implements ElementParser {
     return g;
   }
 
-  collect(into: PIXI.Container, el: UIElement, collect: (into: PIXI.Container, el: UIElement) => void) {
+  collect(into: RenderContainer, el: UIElement, collect: (into: RenderContainer, el: UIElement) => void) {
     if (el instanceof Grid) {
       for (const ch of el.children) collect(into, ch);
       el.debugG.zIndex = 100000;
-      if (el.debugG.parent !== into) {
-        el.debugG.parent?.removeChild(el.debugG);
+      const parent = (el.debugG as any).parent;
+      const intoObj = into.getDisplayObject();
+      if (parent !== intoObj) {
+        parent?.removeChild?.(el.debugG);
         into.addChild(el.debugG);
       }
       return true;

--- a/packages/parser/src/parsers/ImageParser.ts
+++ b/packages/parser/src/parsers/ImageParser.ts
@@ -3,6 +3,7 @@ import { applyGridAttachedProps, parseSizeAttrs, applyMargin, applyAlignment } f
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
 import type { UIElement } from '../../../runtime/src/core.js';
+import type { RenderContainer } from '../../../runtime/src/renderer.js';
 
 /** Parser for `<Image>` elements. */
 export class ImageParser implements ElementParser {
@@ -22,7 +23,7 @@ export class ImageParser implements ElementParser {
     return img;
   }
 
-  collect(into: any, el: UIElement) {
+  collect(into: RenderContainer, el: UIElement) {
     if (el instanceof Image) {
       into.addChild(el.sprite.getDisplayObject());
       return true;

--- a/packages/parser/src/parsers/TextBlockParser.ts
+++ b/packages/parser/src/parsers/TextBlockParser.ts
@@ -3,7 +3,7 @@ import { applyGridAttachedProps, parseSizeAttrs, applyMargin, applyAlignment } f
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
 import type { UIElement } from '../../../runtime/src/core.js';
-import type * as PIXI from 'pixi.js';
+import type { RenderContainer } from '../../../runtime/src/renderer.js';
 
 /** Parser for `<TextBlock>` elements. */
 export class TextBlockParser implements ElementParser {
@@ -20,7 +20,7 @@ export class TextBlockParser implements ElementParser {
     return leaf;
   }
 
-  collect(into: PIXI.Container, el: UIElement) {
+  collect(into: RenderContainer, el: UIElement) {
     if (el instanceof Text) {
       into.addChild(el.text.getDisplayObject());
       return true;

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import MonacoEditor from 'react-monaco-editor';
 import * as PIXI from 'pixi.js';
-import { RuntimeInstance } from '@noxigui/runtime';
+import { RuntimeInstance, RenderContainer } from '@noxigui/runtime';
 import { createPixiRenderer } from '@noxigui/renderer-pixi';
 
 const initialSchema = `
@@ -55,7 +55,7 @@ const initialSchema = `
 </Grid>`;
 
 type RuntimeHandle = {
-  container: PIXI.Container;
+  container: RenderContainer;
   layout: (size: { width: number; height: number }) => void;
   destroy: () => void;
 };
@@ -131,7 +131,7 @@ export default function App() {
       runtimeRef.current = runtime;
       // runtime.setGridDebug(true);
 
-      app.stage.addChild(runtime.container);
+      app.stage.addChild(runtime.container.getDisplayObject());
 
       const relayout = () => {
         if (!appRef.current || !runtimeRef.current) return;

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import MonacoEditor from 'react-monaco-editor';
 import * as PIXI from 'pixi.js';
-import { RuntimeInstance, RenderContainer } from '@noxigui/runtime';
+import { RuntimeInstance, type RenderContainer } from '@noxigui/runtime';
 import { createPixiRenderer } from '@noxigui/renderer-pixi';
 
 const initialSchema = `

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -2,7 +2,7 @@ import { Parser } from '../../parser/src/Parser.js';
 import { Grid } from './elements/Grid.js';
 import { UIElement } from './core.js';
 import type { Size } from './core.js';
-import type { Renderer } from './renderer.js';
+import type { Renderer, RenderContainer } from './renderer.js';
 
 export const RuntimeInstance = {
   create(xml: string, renderer: Renderer) {
@@ -22,8 +22,16 @@ export const RuntimeInstance = {
       root.arrange({ x: 0, y: 0, width: size.width, height: size.height });
     };
 
-    const destroy = () => container.destroy({ children: true });
+    const destroy = () => {
+      const obj = container.getDisplayObject();
+      (obj as any)?.destroy?.({ children: true });
+    };
 
-    return { container, layout, destroy, setGridDebug };
+    return { container, layout, destroy, setGridDebug } as {
+      container: RenderContainer;
+      layout: (size: Size) => void;
+      destroy: () => void;
+      setGridDebug: (on: boolean) => void;
+    };
   }
 };


### PR DESCRIPTION
## Summary
- switch ElementParser collect hook to generic `RenderContainer`
- update built-in parsers and parser core to work with renderer containers
- expose renderer-agnostic container through RuntimeInstance and playground

## Testing
- `pnpm -F @noxigui/runtime build`
- `pnpm -F @noxigui/parser build`
- `pnpm -F @noxigui/renderer-pixi build` *(fails: Cannot find module '@noxigui/runtime')*
- `pnpm -F @noxigui/playground build` *(fails: Cannot find module '@noxigui/runtime')*

------
https://chatgpt.com/codex/tasks/task_e_68b114088ecc832a935447eb12e44a38