### PR TITLE
feat: inject renderer into grid

### DIFF
--- a/packages/parser/src/parsers/GridParser.ts
+++ b/packages/parser/src/parsers/GridParser.ts
@@ -9,7 +9,7 @@ import type { RenderContainer } from '../../../runtime/src/renderer.js';
 export class GridParser implements ElementParser {
   test(node: Element): boolean { return node.tagName === 'Grid'; }
   parse(node: Element, p: Parser) {
-    const g = new Grid();
+    const g = new Grid(p.renderer);
     const rgAttr = node.getAttribute('RowGap'); if (rgAttr != null) g.rowGap = parseFloat(rgAttr) || 0;
     const cgAttr = node.getAttribute('ColumnGap'); if (cgAttr != null) g.colGap = parseFloat(cgAttr) || 0;
     applyMargin(node, g);
@@ -38,12 +38,13 @@ export class GridParser implements ElementParser {
   collect(into: RenderContainer, el: UIElement, collect: (into: RenderContainer, el: UIElement) => void) {
     if (el instanceof Grid) {
       for (const ch of el.children) collect(into, ch);
-      el.debugG.zIndex = 100000;
-      const parent = (el.debugG as any).parent;
+      const gObj = el.debugG.getDisplayObject();
+      gObj.zIndex = 100000;
+      const parent = gObj.parent;
       const intoObj = into.getDisplayObject();
       if (parent !== intoObj) {
-        parent?.removeChild?.(el.debugG);
-        into.addChild(el.debugG);
+        parent?.removeChild?.(gObj);
+        into.addChild(gObj);
       }
       return true;
     }

--- a/packages/runtime/src/elements/Grid.ts
+++ b/packages/runtime/src/elements/Grid.ts
@@ -1,7 +1,7 @@
-import * as PIXI from 'pixi.js';
 import { UIElement } from '../core.js';
 import type { Size, Rect } from '../core.js';
 import type { Len } from '../helpers.js';
+import type { Renderer, RenderGraphics } from '../renderer.js';
 import { BorderPanel } from './BorderPanel.js';
 
 export class Row { actual = 0; desired = 0; constructor(public len: Len) {} }
@@ -20,7 +20,12 @@ export class Grid extends UIElement {
   colGap = 0;
 
   debug = false;
-  debugG = new PIXI.Graphics();
+  debugG: RenderGraphics;
+
+  constructor(renderer: Renderer) {
+    super();
+    this.debugG = renderer.createGraphics();
+  }
 
   add(ch: UIElement) { this.children.push(ch); }
   static setRow(el: UIElement, i: number) { rowMap.set(el, i|0); }
@@ -193,7 +198,7 @@ export class Grid extends UIElement {
   }
 
   private drawDebug(xs: number[], ys: number[]) {
-    const g = this.debugG;
+    const g: any = this.debugG.getDisplayObject();
     g.visible = this.debug;
     g.clear();
     if (!this.debug) return;


### PR DESCRIPTION
## Summary
- pass `Renderer` to `Grid` constructor and create debug graphics via renderer
- forward parser's renderer when building `Grid`
- adapt debug graphic collection to renderer abstraction

## Testing
- `pnpm -F @noxigui/runtime build`
- `pnpm -F @noxigui/parser build`


------
https://chatgpt.com/codex/tasks/task_e_68b147579c10832a9b1dc10234b850f0