### PR TITLE
refactor parser imports to runtime package

### DIFF
--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@noxigui/runtime": "file:../runtime"
+  },
   "devDependencies": {
     "typescript": "~5.8.3"
   }

--- a/packages/parser/src/Parser.ts
+++ b/packages/parser/src/Parser.ts
@@ -1,6 +1,6 @@
-import { UIElement } from '../../runtime/src/core.js';
+import { UIElement } from '@noxigui/runtime/core.js';
 import { parsers as elementParsers } from './parsers/index.js';
-import type { Renderer, RenderContainer } from '../../runtime/src/renderer.js';
+import type { Renderer, RenderContainer } from '@noxigui/runtime/renderer.js';
 
 /**
  * Parses NoxiGUI XML markup into UI elements and a PIXI display tree.

--- a/packages/parser/src/Parser.ts
+++ b/packages/parser/src/Parser.ts
@@ -1,6 +1,6 @@
-import { UIElement } from '@noxigui/runtime/core.js';
+import { UIElement } from '@noxigui/runtime';
 import { parsers as elementParsers } from './parsers/index.js';
-import type { Renderer, RenderContainer } from '@noxigui/runtime/renderer.js';
+import type { Renderer, RenderContainer } from '@noxigui/runtime';
 
 /**
  * Parses NoxiGUI XML markup into UI elements and a PIXI display tree.

--- a/packages/parser/src/parsers/BorderParser.ts
+++ b/packages/parser/src/parsers/BorderParser.ts
@@ -1,9 +1,9 @@
-import { BorderPanel } from '../../../runtime/src/elements/BorderPanel.js';
-import { applyGridAttachedProps, parseSizeAttrs, parseColor, parseMargin, applyMargin } from '../../../runtime/src/helpers.js';
+import { BorderPanel } from '@noxigui/runtime/elements/BorderPanel.js';
+import { applyGridAttachedProps, parseSizeAttrs, parseColor, parseMargin, applyMargin } from '@noxigui/runtime/helpers.js';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
-import type { UIElement } from '../../../runtime/src/core.js';
-import type { RenderContainer } from '../../../runtime/src/renderer.js';
+import type { UIElement } from '@noxigui/runtime/core.js';
+import type { RenderContainer } from '@noxigui/runtime/renderer.js';
 
 /** Parser for `<Border>` elements. */
 export class BorderParser implements ElementParser {

--- a/packages/parser/src/parsers/BorderParser.ts
+++ b/packages/parser/src/parsers/BorderParser.ts
@@ -1,9 +1,7 @@
-import { BorderPanel } from '@noxigui/runtime/elements/BorderPanel.js';
-import { applyGridAttachedProps, parseSizeAttrs, parseColor, parseMargin, applyMargin } from '@noxigui/runtime/helpers.js';
+import { BorderPanel, applyGridAttachedProps, parseSizeAttrs, parseColor, parseMargin, applyMargin } from '@noxigui/runtime';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
-import type { UIElement } from '@noxigui/runtime/core.js';
-import type { RenderContainer } from '@noxigui/runtime/renderer.js';
+import type { UIElement, RenderContainer } from '@noxigui/runtime';
 
 /** Parser for `<Border>` elements. */
 export class BorderParser implements ElementParser {

--- a/packages/parser/src/parsers/ContentPresenterParser.ts
+++ b/packages/parser/src/parsers/ContentPresenterParser.ts
@@ -1,9 +1,7 @@
-import { ContentPresenter } from '@noxigui/runtime/core.js';
-import { applyGridAttachedProps, applyMargin } from '@noxigui/runtime/helpers.js';
+import { ContentPresenter, applyGridAttachedProps, applyMargin } from '@noxigui/runtime';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
-import type { UIElement } from '@noxigui/runtime/core.js';
-import type { RenderContainer } from '@noxigui/runtime/renderer.js';
+import type { UIElement, RenderContainer } from '@noxigui/runtime';
 
 /** Parser for `<ContentPresenter>` elements. */
 export class ContentPresenterParser implements ElementParser {

--- a/packages/parser/src/parsers/ContentPresenterParser.ts
+++ b/packages/parser/src/parsers/ContentPresenterParser.ts
@@ -1,9 +1,9 @@
-import { ContentPresenter } from '../../../runtime/src/core.js';
-import { applyGridAttachedProps, applyMargin } from '../../../runtime/src/helpers.js';
+import { ContentPresenter } from '@noxigui/runtime/core.js';
+import { applyGridAttachedProps, applyMargin } from '@noxigui/runtime/helpers.js';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
-import type { UIElement } from '../../../runtime/src/core.js';
-import type { RenderContainer } from '../../../runtime/src/renderer.js';
+import type { UIElement } from '@noxigui/runtime/core.js';
+import type { RenderContainer } from '@noxigui/runtime/renderer.js';
 
 /** Parser for `<ContentPresenter>` elements. */
 export class ContentPresenterParser implements ElementParser {

--- a/packages/parser/src/parsers/ElementParser.ts
+++ b/packages/parser/src/parsers/ElementParser.ts
@@ -1,6 +1,6 @@
-import type { UIElement } from '../../../runtime/src/core.js';
+import type { UIElement } from '@noxigui/runtime/core.js';
 import type { Parser } from '../Parser.js';
-import type { RenderContainer } from '../../../runtime/src/renderer.js';
+import type { RenderContainer } from '@noxigui/runtime/renderer.js';
 
 /**
  * Converts DOM nodes into runtime UI elements.

--- a/packages/parser/src/parsers/ElementParser.ts
+++ b/packages/parser/src/parsers/ElementParser.ts
@@ -1,6 +1,5 @@
-import type { UIElement } from '@noxigui/runtime/core.js';
 import type { Parser } from '../Parser.js';
-import type { RenderContainer } from '@noxigui/runtime/renderer.js';
+import type { UIElement, RenderContainer } from '@noxigui/runtime';
 
 /**
  * Converts DOM nodes into runtime UI elements.

--- a/packages/parser/src/parsers/GridParser.ts
+++ b/packages/parser/src/parsers/GridParser.ts
@@ -1,9 +1,7 @@
-import { Grid, Row, Col } from '@noxigui/runtime/elements/Grid.js';
-import { applyGridAttachedProps, parseLen, applyMargin } from '@noxigui/runtime/helpers.js';
+import { Grid, Row, Col, applyGridAttachedProps, parseLen, applyMargin } from '@noxigui/runtime';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
-import type { UIElement } from '@noxigui/runtime/core.js';
-import type { RenderContainer } from '@noxigui/runtime/renderer.js';
+import type { UIElement, RenderContainer } from '@noxigui/runtime';
 
 /** Parser for `<Grid>` elements. */
 export class GridParser implements ElementParser {

--- a/packages/parser/src/parsers/GridParser.ts
+++ b/packages/parser/src/parsers/GridParser.ts
@@ -1,9 +1,9 @@
-import { Grid, Row, Col } from '../../../runtime/src/elements/Grid.js';
-import { applyGridAttachedProps, parseLen, applyMargin } from '../../../runtime/src/helpers.js';
+import { Grid, Row, Col } from '@noxigui/runtime/elements/Grid.js';
+import { applyGridAttachedProps, parseLen, applyMargin } from '@noxigui/runtime/helpers.js';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
-import type { UIElement } from '../../../runtime/src/core.js';
-import type { RenderContainer } from '../../../runtime/src/renderer.js';
+import type { UIElement } from '@noxigui/runtime/core.js';
+import type { RenderContainer } from '@noxigui/runtime/renderer.js';
 
 /** Parser for `<Grid>` elements. */
 export class GridParser implements ElementParser {

--- a/packages/parser/src/parsers/ImageParser.ts
+++ b/packages/parser/src/parsers/ImageParser.ts
@@ -1,9 +1,9 @@
-import { Image } from '../../../runtime/src/elements/Image.js';
-import { applyGridAttachedProps, parseSizeAttrs, applyMargin, applyAlignment } from '../../../runtime/src/helpers.js';
+import { Image } from '@noxigui/runtime/elements/Image.js';
+import { applyGridAttachedProps, parseSizeAttrs, applyMargin, applyAlignment } from '@noxigui/runtime/helpers.js';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
-import type { UIElement } from '../../../runtime/src/core.js';
-import type { RenderContainer } from '../../../runtime/src/renderer.js';
+import type { UIElement } from '@noxigui/runtime/core.js';
+import type { RenderContainer } from '@noxigui/runtime/renderer.js';
 
 /** Parser for `<Image>` elements. */
 export class ImageParser implements ElementParser {

--- a/packages/parser/src/parsers/ImageParser.ts
+++ b/packages/parser/src/parsers/ImageParser.ts
@@ -1,9 +1,7 @@
-import { Image } from '@noxigui/runtime/elements/Image.js';
-import { applyGridAttachedProps, parseSizeAttrs, applyMargin, applyAlignment } from '@noxigui/runtime/helpers.js';
+import { Image, applyGridAttachedProps, parseSizeAttrs, applyMargin, applyAlignment } from '@noxigui/runtime';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
-import type { UIElement } from '@noxigui/runtime/core.js';
-import type { RenderContainer } from '@noxigui/runtime/renderer.js';
+import type { UIElement, RenderContainer } from '@noxigui/runtime';
 
 /** Parser for `<Image>` elements. */
 export class ImageParser implements ElementParser {

--- a/packages/parser/src/parsers/ResourcesParser.ts
+++ b/packages/parser/src/parsers/ResourcesParser.ts
@@ -1,4 +1,4 @@
-import { registerTemplate } from '@noxigui/runtime/template.js';
+import { registerTemplate } from '@noxigui/runtime';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
 

--- a/packages/parser/src/parsers/ResourcesParser.ts
+++ b/packages/parser/src/parsers/ResourcesParser.ts
@@ -1,4 +1,4 @@
-import { registerTemplate } from '../../../runtime/src/template.js';
+import { registerTemplate } from '@noxigui/runtime/template.js';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
 

--- a/packages/parser/src/parsers/TextBlockParser.ts
+++ b/packages/parser/src/parsers/TextBlockParser.ts
@@ -1,9 +1,9 @@
-import { Text } from '../../../runtime/src/elements/Text.js';
-import { applyGridAttachedProps, parseSizeAttrs, applyMargin, applyAlignment } from '../../../runtime/src/helpers.js';
+import { Text } from '@noxigui/runtime/elements/Text.js';
+import { applyGridAttachedProps, parseSizeAttrs, applyMargin, applyAlignment } from '@noxigui/runtime/helpers.js';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
-import type { UIElement } from '../../../runtime/src/core.js';
-import type { RenderContainer } from '../../../runtime/src/renderer.js';
+import type { UIElement } from '@noxigui/runtime/core.js';
+import type { RenderContainer } from '@noxigui/runtime/renderer.js';
 
 /** Parser for `<TextBlock>` elements. */
 export class TextBlockParser implements ElementParser {

--- a/packages/parser/src/parsers/TextBlockParser.ts
+++ b/packages/parser/src/parsers/TextBlockParser.ts
@@ -1,9 +1,7 @@
-import { Text } from '@noxigui/runtime/elements/Text.js';
-import { applyGridAttachedProps, parseSizeAttrs, applyMargin, applyAlignment } from '@noxigui/runtime/helpers.js';
+import { Text, applyGridAttachedProps, parseSizeAttrs, applyMargin, applyAlignment } from '@noxigui/runtime';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
-import type { UIElement } from '@noxigui/runtime/core.js';
-import type { RenderContainer } from '@noxigui/runtime/renderer.js';
+import type { UIElement, RenderContainer } from '@noxigui/runtime';
 
 /** Parser for `<TextBlock>` elements. */
 export class TextBlockParser implements ElementParser {

--- a/packages/parser/src/parsers/UseParser.ts
+++ b/packages/parser/src/parsers/UseParser.ts
@@ -1,4 +1,4 @@
-import { instantiateTemplate } from '../../../runtime/src/template.js';
+import { instantiateTemplate } from '@noxigui/runtime/template.js';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
 

--- a/packages/parser/src/parsers/UseParser.ts
+++ b/packages/parser/src/parsers/UseParser.ts
@@ -1,4 +1,4 @@
-import { instantiateTemplate } from '@noxigui/runtime/template.js';
+import { instantiateTemplate } from '@noxigui/runtime';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
 

--- a/packages/parser/tsconfig.json
+++ b/packages/parser/tsconfig.json
@@ -5,7 +5,12 @@
     "declaration": true,
     "declarationMap": true,
     "allowImportingTsExtensions": false,
-    "erasableSyntaxOnly": false
+    "erasableSyntaxOnly": false,
+    "baseUrl": "src",
+    "paths": {
+      "@noxigui/runtime": ["../../runtime/dist/runtime/src/index.js"],
+      "@noxigui/runtime/*": ["../../runtime/dist/runtime/src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/packages/parser/tsconfig.json
+++ b/packages/parser/tsconfig.json
@@ -8,8 +8,7 @@
     "erasableSyntaxOnly": false,
     "baseUrl": "src",
     "paths": {
-      "@noxigui/runtime": ["../../runtime/dist/runtime/src/index.js"],
-      "@noxigui/runtime/*": ["../../runtime/dist/runtime/src/*"]
+      "@noxigui/runtime": ["../../runtime/dist/runtime/src/index.d.ts"]
     }
   },
   "include": ["src"]

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "pixi.js": "^7.4.3",
-    "@noxigui/parser": "file:../parser",
     "@noxigui/core": "file:../core"
   },
   "devDependencies": {

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -9,7 +9,9 @@
     "baseUrl": "src",
     "paths": {
       "@noxigui/core": ["../core/src/index.ts"],
-      "@noxigui/core/*": ["../core/src/*"]
+      "@noxigui/core/*": ["../core/src/*"],
+      "@noxigui/runtime": ["./index.ts"],
+      "@noxigui/runtime/*": ["./*"]
     },
     "moduleResolution": "node"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,9 +19,9 @@ importers:
 
   packages/parser:
     dependencies:
-      pixi.js:
-        specifier: ^7.4.3
-        version: 7.4.3
+      '@noxigui/runtime':
+        specifier: file:../runtime
+        version: link:../runtime
     devDependencies:
       typescript:
         specifier: ~5.8.3
@@ -81,9 +81,6 @@ importers:
       '@noxigui/core':
         specifier: file:../core
         version: link:../core
-      '@noxigui/parser':
-        specifier: file:../parser
-        version: link:../parser
       pixi.js:
         specifier: ^7.4.3
         version: 7.4.3


### PR DESCRIPTION
## Summary
- replace parser's relative runtime imports with `@noxigui/runtime`
- configure TypeScript and package metadata for runtime path resolution
- remove parser dependency from runtime to keep packages acyclic

## Testing
- `pnpm install`
- `node scripts/build-packages.js`


------
https://chatgpt.com/codex/tasks/task_e_68b148bbcac8832abb0087385a209a9d