### PR TITLE
refactor(runtime): reuse core UIElement

### DIFF
--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -1,7 +1,4 @@
-// Runtime base UIElement built on core RuleRegistry
-
-import type { MeasureCtx } from '../../core/src/index.js';
-import { createDefaultRegistry, RuleRegistry } from '../../core/src/index.js';
+import { UIElement as CoreUIElement, createDefaultRegistry, type Axis, type MeasureCtx } from '../../core/src/index.js';
 
 export type Size = { width: number; height: number };
 export type Rect = { x: number; y: number; width: number; height: number };
@@ -9,42 +6,43 @@ export type Rect = { x: number; y: number; width: number; height: number };
 const defaultRegistry = createDefaultRegistry();
 
 /**
- * Basic UI element supporting margin and preferred/min sizes. The size
- * computation is delegated to the core RuleRegistry to avoid duplicating
- * clamp logic across runtime elements.
+ * Framework element extending the core {@link UIElement} with margin and
+ * preferred/minimum sizing support. Measurement delegates to the core rule
+ * registry to keep logic centralized.
  */
-export abstract class UIElement {
-  desired: Size = { width: 0, height: 0 };
+export abstract class UIElement extends CoreUIElement {
   final: Rect = { x: 0, y: 0, width: 0, height: 0 };
 
   margin = { l: 0, t: 0, r: 0, b: 0 };
   minW = 0; minH = 0;
   prefW?: number; prefH?: number;
 
-  protected registry: RuleRegistry = defaultRegistry;
+  constructor() { super(defaultRegistry); }
 
-  protected measureAxis(axis: 'x' | 'y', avail: number, intrinsic: number): number {
-    const pref = axis === 'x' ? this.prefW : this.prefH;
+  protected override ctx(axis: Axis, available: number): MeasureCtx {
+    const ctx = super.ctx(axis, available);
     const marginSum = axis === 'x' ? this.margin.l + this.margin.r : this.margin.t + this.margin.b;
-    const min = (axis === 'x' ? this.minW : this.minH) + marginSum;
-    const prefVal = pref !== undefined ? pref + marginSum : undefined;
-    const style = prefVal !== undefined ? { unit: 'px', value: prefVal } as const : { unit: 'auto' } as const;
-    const ctx: MeasureCtx = {
-      axis,
-      box: { marginStart: 0, marginEnd: 0, borderStart: 0, borderEnd: 0, paddingStart: 0, paddingEnd: 0 },
-      style,
-      constraints: { available: avail, min },
-      intrinsic,
-    };
-    return this.registry.run(ctx);
+    ctx.constraints.min = (axis === 'x' ? this.minW : this.minH) + marginSum;
+    return ctx;
   }
 
-  abstract measure(avail: Size): void;
+  measure(avail: Size): void {
+    this.boxX.marginStart = this.margin.l; this.boxX.marginEnd = this.margin.r;
+    this.boxY.marginStart = this.margin.t; this.boxY.marginEnd = this.margin.b;
+    this.styleX = this.prefW !== undefined
+      ? { unit: 'px', value: this.prefW + this.margin.l + this.margin.r }
+      : { unit: 'auto' };
+    this.styleY = this.prefH !== undefined
+      ? { unit: 'px', value: this.prefH + this.margin.t + this.margin.b }
+      : { unit: 'auto' };
+    super.measure(avail);
+  }
+
   abstract arrange(rect: Rect): void;
 }
 
 /**
- * Simple presenter that proxies measurement and arrangement to a single child.
+ * Presenter that proxies measurement and arrangement to a single child.
  */
 export class ContentPresenter extends UIElement {
   child?: UIElement;
@@ -52,20 +50,13 @@ export class ContentPresenter extends UIElement {
   measure(avail: Size) {
     if (this.child) {
       this.child.measure(avail);
-      const intrinsicW = this.child.desired.width + this.margin.l + this.margin.r;
-      const intrinsicH = this.child.desired.height + this.margin.t + this.margin.b;
-      this.desired = {
-        width: this.measureAxis('x', avail.width, intrinsicW),
-        height: this.measureAxis('y', avail.height, intrinsicH),
-      };
+      this.intrinsicWidth = this.child.desired.width + this.margin.l + this.margin.r;
+      this.intrinsicHeight = this.child.desired.height + this.margin.t + this.margin.b;
     } else {
-      const intrinsicW = this.margin.l + this.margin.r;
-      const intrinsicH = this.margin.t + this.margin.b;
-      this.desired = {
-        width: this.measureAxis('x', avail.width, intrinsicW),
-        height: this.measureAxis('y', avail.height, intrinsicH),
-      };
+      this.intrinsicWidth = this.margin.l + this.margin.r;
+      this.intrinsicHeight = this.margin.t + this.margin.b;
     }
+    super.measure(avail);
   }
 
   arrange(rect: Rect) {
@@ -76,4 +67,3 @@ export class ContentPresenter extends UIElement {
     if (this.child) this.child.arrange({ x, y, width: w, height: h });
   }
 }
-

--- a/packages/runtime/src/elements/BorderPanel.ts
+++ b/packages/runtime/src/elements/BorderPanel.ts
@@ -27,17 +27,16 @@ export class BorderPanel extends UIElement {
       width: Math.max(0, avail.width - this.margin.l - this.margin.r - this.padding.l - this.padding.r),
       height: Math.max(0, avail.height - this.margin.t - this.margin.b - this.padding.t - this.padding.b),
     };
-    let intrinsicW = this.margin.l + this.margin.r + this.padding.l + this.padding.r;
-    let intrinsicH = this.margin.t + this.margin.b + this.padding.t + this.padding.b;
+    let contentW = this.padding.l + this.padding.r;
+    let contentH = this.padding.t + this.padding.b;
     if (this.child) {
       this.child.measure(inner);
-      intrinsicW += this.child.desired.width;
-      intrinsicH += this.child.desired.height;
+      contentW += this.child.desired.width;
+      contentH += this.child.desired.height;
     }
-    this.desired = {
-      width: this.measureAxis('x', avail.width, intrinsicW),
-      height: this.measureAxis('y', avail.height, intrinsicH),
-    };
+    this.intrinsicWidth = contentW + this.margin.l + this.margin.r;
+    this.intrinsicHeight = contentH + this.margin.t + this.margin.b;
+    super.measure(avail);
   }
 
   arrange(rect: Rect) {

--- a/packages/runtime/src/elements/Grid.ts
+++ b/packages/runtime/src/elements/Grid.ts
@@ -152,12 +152,9 @@ export class Grid extends UIElement {
     const widthSum = this.cols.reduce((s, c) => s + c.actual, 0) + totalColGaps;
     const heightSum = this.rows.reduce((s, r) => s + r.actual, 0) + totalRowGaps;
 
-    const intrinsicW = widthSum + this.margin.l + this.margin.r;
-    const intrinsicH = heightSum + this.margin.t + this.margin.b;
-    this.desired = {
-      width: this.measureAxis('x', avail.width, intrinsicW),
-      height: this.measureAxis('y', avail.height, intrinsicH),
-    };
+    this.intrinsicWidth = widthSum + this.margin.l + this.margin.r;
+    this.intrinsicHeight = heightSum + this.margin.t + this.margin.b;
+    super.measure(avail);
   }
 
   arrange(rect: Rect) {

--- a/packages/runtime/src/elements/Image.ts
+++ b/packages/runtime/src/elements/Image.ts
@@ -36,33 +36,24 @@ export class Image extends UIElement {
     const baseH = natH > 0 ? natH : fallback;
 
     if (this.prefW !== undefined && this.prefH !== undefined) {
-      const intrinsicW = this.prefW + this.margin.l + this.margin.r;
-      const intrinsicH = this.prefH + this.margin.t + this.margin.b;
-      this.desired = {
-        width: this.measureAxis('x', avail.width, intrinsicW),
-        height: this.measureAxis('y', avail.height, intrinsicH)
-      };
+      this.intrinsicWidth = this.prefW + this.margin.l + this.margin.r;
+      this.intrinsicHeight = this.prefH + this.margin.t + this.margin.b;
+      super.measure(avail);
       return;
     }
 
     if (this.prefW !== undefined && this.prefH === undefined) {
       const h = baseH * (this.prefW / baseW);
-      const intrinsicW = this.prefW + this.margin.l + this.margin.r;
-      const intrinsicH = h + this.margin.t + this.margin.b;
-      this.desired = {
-        width: this.measureAxis('x', avail.width, intrinsicW),
-        height: this.measureAxis('y', avail.height, intrinsicH)
-      };
+      this.intrinsicWidth = this.prefW + this.margin.l + this.margin.r;
+      this.intrinsicHeight = h + this.margin.t + this.margin.b;
+      super.measure(avail);
       return;
     }
     if (this.prefH !== undefined && this.prefW === undefined) {
       const w = baseW * (this.prefH / baseH);
-      const intrinsicW = w + this.margin.l + this.margin.r;
-      const intrinsicH = this.prefH + this.margin.t + this.margin.b;
-      this.desired = {
-        width: this.measureAxis('x', avail.width, intrinsicW),
-        height: this.measureAxis('y', avail.height, intrinsicH)
-      };
+      this.intrinsicWidth = w + this.margin.l + this.margin.r;
+      this.intrinsicHeight = this.prefH + this.margin.t + this.margin.b;
+      super.measure(avail);
       return;
     }
 
@@ -104,12 +95,9 @@ export class Image extends UIElement {
       }
     }
 
-    const intrinsicW = drawW + this.margin.l + this.margin.r;
-    const intrinsicH = drawH + this.margin.t + this.margin.b;
-    this.desired = {
-      width: this.measureAxis('x', avail.width, intrinsicW),
-      height: this.measureAxis('y', avail.height, intrinsicH)
-    };
+    this.intrinsicWidth = drawW + this.margin.l + this.margin.r;
+    this.intrinsicHeight = drawH + this.margin.t + this.margin.b;
+    super.measure(avail);
   }
 
   arrange(rect: Rect) {

--- a/packages/runtime/src/elements/Text.ts
+++ b/packages/runtime/src/elements/Text.ts
@@ -15,12 +15,9 @@ export class Text extends UIElement {
   measure(avail: Size) {
     this.text.setWordWrap(Math.max(1, avail.width), 'left');
     const b = this.text.getBounds();
-    const intrinsicW = b.width + this.margin.l + this.margin.r;
-    const intrinsicH = b.height + this.margin.t + this.margin.b;
-    this.desired = {
-      width: this.measureAxis('x', avail.width, intrinsicW),
-      height: this.measureAxis('y', avail.height, intrinsicH)
-    };
+    this.intrinsicWidth = b.width + this.margin.l + this.margin.r;
+    this.intrinsicHeight = b.height + this.margin.t + this.margin.b;
+    super.measure(avail);
   }
 
   arrange(rect: Rect) {


### PR DESCRIPTION
## Summary
- reuse core UIElement by extending it in runtime
- update runtime elements to rely on rule registry via super.measure

## Testing
- `pnpm -F @noxigui/runtime build`
- `pnpm -F @noxigui/core test`


------
https://chatgpt.com/codex/tasks/task_e_68b157fcf4e4832a81856d7b29f1ab96