### PR TITLE
refactor runtime to use packaged core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,9 +2,14 @@
   "name": "@noxigui/core",
   "version": "0.2.0",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "exports": "./dist/index.js",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/src/index.js",
+      "types": "./dist/src/index.d.ts"
+    }
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "tsc -p tsconfig.json && node --test dist/tests/layout/*.test.js"

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "baseUrl": "src",
+    "paths": {
+      "@noxigui/runtime": ["../../runtime/dist/runtime/src/index.d.ts"],
+      "@noxigui/core": ["../../core/dist/src/index.d.ts"]
+    }
   },
   "include": ["src"]
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -4,7 +4,12 @@
   "type": "module",
   "main": "dist/runtime/src/index.js",
   "types": "dist/runtime/src/index.d.ts",
-  "exports": "./dist/runtime/src/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/runtime/src/index.js",
+      "types": "./dist/runtime/src/index.d.ts"
+    }
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -1,7 +1,7 @@
 // Runtime base UIElement built on core RuleRegistry
 
-import type { MeasureCtx } from '../../core/src/index.js';
-import { createDefaultRegistry, RuleRegistry } from '../../core/src/index.js';
+import type { MeasureCtx } from '@noxigui/core';
+import { createDefaultRegistry, RuleRegistry } from '@noxigui/core';
 
 export type Size = { width: number; height: number };
 export type Rect = { x: number; y: number; width: number; height: number };

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,6 +1,6 @@
 export * from './template.js';
 export * from './core.js';
-export { createDefaultRegistry, RuleRegistry } from '../../core/src/index.js';
+export { createDefaultRegistry, RuleRegistry } from '@noxigui/core';
 export * from './elements/BorderPanel.js';
 export * from './elements/Image.js';
 export * from './elements/Text.js';

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -8,8 +8,8 @@
     "erasableSyntaxOnly": false,
     "baseUrl": "src",
     "paths": {
-      "@noxigui/core": ["../core/src/index.ts"],
-      "@noxigui/core/*": ["../core/src/*"],
+      "@noxigui/core": ["../../core/dist/src/index.d.ts"],
+      "@noxigui/core/*": ["../../core/dist/src/*"],
       "@noxigui/parser": ["../../parser/src/index.ts"],
       "@noxigui/parser/*": ["../../parser/src/*"],
       "@noxigui/runtime": ["./index.ts"],


### PR DESCRIPTION
## Summary
- import `@noxigui/core` from runtime instead of accessing core sources
- point runtime TypeScript config to built core artifacts
- expose built entry points in core and runtime package manifests
- wire playground TypeScript config to built runtime and core outputs

## Testing
- `pnpm build` *(fails: Failed to resolve entry for package "@noxigui/runtime" during playground build)*
- `pnpm -F @noxigui/core build`
- `pnpm -F @noxigui/runtime build`


------
https://chatgpt.com/codex/tasks/task_e_68b160eea2f4832ab33c522b9a2c0647