### PR TITLE
refactor: centralize runtime element base

### DIFF
--- a/packages/core/src/elements/UIElement.ts
+++ b/packages/core/src/elements/UIElement.ts
@@ -1,38 +1,63 @@
-import type { Axis, AxisBox, AxisStyle, AxisConstraints, MeasureCtx } from '../layout/engine.js';
+import type { MeasureCtx } from '../layout/engine.js';
 import { RuleRegistry } from '../layout/engine.js';
+import { createDefaultRegistry } from '../layout/register-defaults.js';
 
-export interface Size { width: number; height: number; }
+export type Size = { width: number; height: number };
+export type Rect = { x: number; y: number; width: number; height: number };
 
-function defaultBox(): AxisBox {
-  return { marginStart: 0, marginEnd: 0, borderStart: 0, borderEnd: 0, paddingStart: 0, paddingEnd: 0 };
-}
+const defaultRegistry = createDefaultRegistry();
 
-export class UIElement {
-  protected boxX: AxisBox = defaultBox();
-  protected boxY: AxisBox = defaultBox();
-  protected styleX: AxisStyle = { unit: 'auto' };
-  protected styleY: AxisStyle = { unit: 'auto' };
-  protected intrinsicWidth?: number;
-  protected intrinsicHeight?: number;
+/**
+ * Core UI element providing margin, preferred/min sizes and box measurement
+ * backed by the layout rule registry.
+ */
+export abstract class UIElement {
   desired: Size = { width: 0, height: 0 };
+  final: Rect = { x: 0, y: 0, width: 0, height: 0 };
 
-  constructor(protected registry: RuleRegistry) {}
+  margin = { l: 0, t: 0, r: 0, b: 0 };
+  minW = 0; minH = 0;
+  prefW?: number; prefH?: number;
 
-  protected ctx(axis: Axis, available: number): MeasureCtx {
-    const style = axis === 'x' ? this.styleX : this.styleY;
-    const box = axis === 'x' ? this.boxX : this.boxY;
-    const intrinsic = axis === 'x' ? this.intrinsicWidth : this.intrinsicHeight;
-    const pairedIntrinsic = axis === 'x' ? this.intrinsicHeight : this.intrinsicWidth;
-    const constraints: AxisConstraints = { available };
-    return { axis, box, style, constraints, intrinsic, pairedIntrinsic };
+  protected registry: RuleRegistry;
+
+  constructor(registry: RuleRegistry = defaultRegistry) {
+    this.registry = registry;
   }
 
-  protected ctxX(avail: number): MeasureCtx { return this.ctx('x', avail); }
-  protected ctxY(avail: number): MeasureCtx { return this.ctx('y', avail); }
-
-  measure(avail: Size): void {
-    const width = this.registry.run(this.ctxX(avail.width));
-    const height = this.registry.run(this.ctxY(avail.height));
-    this.desired = { width, height };
+  protected measureAxis(axis: 'x' | 'y', avail: number, intrinsic: number): number {
+    const pref = axis === 'x' ? this.prefW : this.prefH;
+    const marginSum = axis === 'x'
+      ? this.margin.l + this.margin.r
+      : this.margin.t + this.margin.b;
+    const min = (axis === 'x' ? this.minW : this.minH) + marginSum;
+    const prefVal = pref !== undefined ? pref + marginSum : undefined;
+    const style = prefVal !== undefined
+      ? ({ unit: 'px', value: prefVal } as const)
+      : ({ unit: 'auto' } as const);
+    const ctx: MeasureCtx = {
+      axis,
+      box: { marginStart: 0, marginEnd: 0, borderStart: 0, borderEnd: 0, paddingStart: 0, paddingEnd: 0 },
+      style,
+      constraints: { available: avail, min },
+      intrinsic,
+    };
+    return this.registry.run(ctx);
   }
+
+  /**
+     * Apply margin to the given rect, update final bounds and return the inner
+     * rect available for children.
+     */
+  protected arrangeSelf(rect: Rect): Rect {
+    const x = rect.x + this.margin.l;
+    const y = rect.y + this.margin.t;
+    const width = Math.max(0, rect.width - this.margin.l - this.margin.r);
+    const height = Math.max(0, rect.height - this.margin.t - this.margin.b);
+    this.final = { x, y, width, height };
+    return this.final;
+  }
+
+  abstract measure(avail: Size): void;
+  abstract arrange(rect: Rect): void;
 }

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -1,47 +1,6 @@
-// Runtime base UIElement built on core RuleRegistry
+import { UIElement, type Size, type Rect } from '@noxigui/core';
 
-import type { MeasureCtx } from '@noxigui/core';
-import { createDefaultRegistry, RuleRegistry } from '@noxigui/core';
-
-export type Size = { width: number; height: number };
-export type Rect = { x: number; y: number; width: number; height: number };
-
-const defaultRegistry = createDefaultRegistry();
-
-/**
- * Basic UI element supporting margin and preferred/min sizes. The size
- * computation is delegated to the core RuleRegistry to avoid duplicating
- * clamp logic across runtime elements.
- */
-export abstract class UIElement {
-  desired: Size = { width: 0, height: 0 };
-  final: Rect = { x: 0, y: 0, width: 0, height: 0 };
-
-  margin = { l: 0, t: 0, r: 0, b: 0 };
-  minW = 0; minH = 0;
-  prefW?: number; prefH?: number;
-
-  protected registry: RuleRegistry = defaultRegistry;
-
-  protected measureAxis(axis: 'x' | 'y', avail: number, intrinsic: number): number {
-    const pref = axis === 'x' ? this.prefW : this.prefH;
-    const marginSum = axis === 'x' ? this.margin.l + this.margin.r : this.margin.t + this.margin.b;
-    const min = (axis === 'x' ? this.minW : this.minH) + marginSum;
-    const prefVal = pref !== undefined ? pref + marginSum : undefined;
-    const style = prefVal !== undefined ? { unit: 'px', value: prefVal } as const : { unit: 'auto' } as const;
-    const ctx: MeasureCtx = {
-      axis,
-      box: { marginStart: 0, marginEnd: 0, borderStart: 0, borderEnd: 0, paddingStart: 0, paddingEnd: 0 },
-      style,
-      constraints: { available: avail, min },
-      intrinsic,
-    };
-    return this.registry.run(ctx);
-  }
-
-  abstract measure(avail: Size): void;
-  abstract arrange(rect: Rect): void;
-}
+export { UIElement, type Size, type Rect } from '@noxigui/core';
 
 /**
  * Simple presenter that proxies measurement and arrangement to a single child.
@@ -69,11 +28,7 @@ export class ContentPresenter extends UIElement {
   }
 
   arrange(rect: Rect) {
-    const x = rect.x + this.margin.l, y = rect.y + this.margin.t;
-    const w = Math.max(0, rect.width - this.margin.l - this.margin.r);
-    const h = Math.max(0, rect.height - this.margin.t - this.margin.b);
-    this.final = { x, y, width: w, height: h };
-    if (this.child) this.child.arrange({ x, y, width: w, height: h });
+    const inner = this.arrangeSelf(rect);
+    if (this.child) this.child.arrange(inner);
   }
 }
-

--- a/packages/runtime/src/elements/BorderPanel.ts
+++ b/packages/runtime/src/elements/BorderPanel.ts
@@ -1,5 +1,4 @@
-import { UIElement } from '../core.js';
-import type { Size, Rect } from '../core.js';
+import { UIElement, type Size, type Rect } from '@noxigui/core';
 import type { Renderer, RenderGraphics, RenderContainer } from '../renderer.js';
 
 export class BorderPanel extends UIElement {
@@ -41,18 +40,14 @@ export class BorderPanel extends UIElement {
   }
 
   arrange(rect: Rect) {
-    const innerX = rect.x + this.margin.l;
-    const innerY = rect.y + this.margin.t;
-    const innerW = Math.max(0, rect.width - this.margin.l - this.margin.r);
-    const innerH = Math.max(0, rect.height - this.margin.t - this.margin.b);
-    this.final = { x: innerX, y: innerY, width: innerW, height: innerH };
+    const inner = this.arrangeSelf(rect);
 
-    this.container.setPosition(innerX, innerY);
+    this.container.setPosition(inner.x, inner.y);
     this.container.setSortableChildren(true);
 
     this.bg.clear();
     if (this.background !== undefined) {
-      this.bg.beginFill(this.background).drawRect(0, 0, innerW, innerH).endFill();
+      this.bg.beginFill(this.background).drawRect(0, 0, inner.width, inner.height).endFill();
     }
 
     if (this.clipToBounds) {
@@ -62,7 +57,7 @@ export class BorderPanel extends UIElement {
         this.container.setMask(this.maskG.getDisplayObject());
       }
       this.maskG.clear();
-      this.maskG.beginFill(0xffffff).drawRect(0, 0, innerW, innerH).endFill();
+      this.maskG.beginFill(0xffffff).drawRect(0, 0, inner.width, inner.height).endFill();
     } else if (this.maskG) {
       this.container.setMask(null);
       this.container.removeChild(this.maskG.getDisplayObject());
@@ -73,8 +68,8 @@ export class BorderPanel extends UIElement {
     if (this.child) {
       const cx = this.padding.l;
       const cy = this.padding.t;
-      const cw = Math.max(0, innerW - this.padding.l - this.padding.r);
-      const ch = Math.max(0, innerH - this.padding.t - this.padding.b);
+      const cw = Math.max(0, inner.width - this.padding.l - this.padding.r);
+      const ch = Math.max(0, inner.height - this.padding.t - this.padding.b);
       this.child.arrange({ x: cx, y: cy, width: cw, height: ch });
     }
   }

--- a/packages/runtime/src/elements/Grid.ts
+++ b/packages/runtime/src/elements/Grid.ts
@@ -1,5 +1,4 @@
-import { UIElement } from '../core.js';
-import type { Size, Rect } from '../core.js';
+import { UIElement, type Size, type Rect } from '@noxigui/core';
 import type { Len } from '../helpers.js';
 import type { Renderer, RenderGraphics } from '../renderer.js';
 import { BorderPanel } from './BorderPanel.js';
@@ -163,11 +162,7 @@ export class Grid extends UIElement {
   arrange(rect: Rect) {
     const rowCount = this.rows.length;
     const colCount = this.cols.length;
-    const innerX = rect.x + this.margin.l;
-    const innerY = rect.y + this.margin.t;
-    const innerW = Math.max(0, rect.width - this.margin.l - this.margin.r);
-    const innerH = Math.max(0, rect.height - this.margin.t - this.margin.b);
-    this.final = { x: innerX, y: innerY, width: innerW, height: innerH };
+    const inner = this.arrangeSelf(rect);
 
     const xs: number[] = [0];
     for (const c of this.cols) xs.push(xs[xs.length - 1] + c.actual);
@@ -185,8 +180,8 @@ export class Grid extends UIElement {
       rs = Math.min(Math.max(1, rs), Math.max(1, rowCount - r));
       cs = Math.min(Math.max(1, cs), Math.max(1, colCount - c));
 
-      const x = xs[c] + c * this.colGap;
-      const y = ys[r] + r * this.rowGap;
+      const x = inner.x + xs[c] + c * this.colGap;
+      const y = inner.y + ys[r] + r * this.rowGap;
 
       const w = (xs[c + cs] - xs[c]) + (cs - 1) * this.colGap;
       const h = (ys[r + rs] - ys[r]) + (rs - 1) * this.rowGap;
@@ -194,7 +189,7 @@ export class Grid extends UIElement {
       ch.arrange({ x, y, width: w, height: h });
     }
 
-    this.drawDebug(xs, ys);
+    this.drawDebug(xs.map(v => v + inner.x), ys.map(v => v + inner.y));
   }
 
   private drawDebug(xs: number[], ys: number[]) {

--- a/packages/runtime/src/elements/Image.ts
+++ b/packages/runtime/src/elements/Image.ts
@@ -1,5 +1,4 @@
-import { UIElement } from '../core.js';
-import type { Size, Rect } from '../core.js';
+import { UIElement, type Size, type Rect } from '@noxigui/core';
 import type { Renderer, RenderImage } from '../renderer.js';
 
 export class Image extends UIElement {
@@ -113,10 +112,8 @@ export class Image extends UIElement {
   }
 
   arrange(rect: Rect) {
-    const x0 = rect.x + this.margin.l, y0 = rect.y + this.margin.t;
-    const w = Math.max(0, rect.width - this.margin.l - this.margin.r);
-    const h = Math.max(0, rect.height - this.margin.t - this.margin.b);
-    this.final = { x: x0, y: y0, width: w, height: h };
+    const inner = this.arrangeSelf(rect);
+    const w = inner.width, h = inner.height;
 
     const sw = this.natW || 1, sh = this.natH || 1;
     let scaleX = 1, scaleY = 1, drawW = sw, drawH = sh;
@@ -128,11 +125,11 @@ export class Image extends UIElement {
       case 'UniformToFill': { const s = Math.max(w / sw, h / sh); scaleX = scaleY = s; drawW = sw * s; drawH = sh * s; break; }
     }
 
-    let x = x0, y = y0;
-    if (this.hAlign === 'Center') x = x0 + (w - drawW) / 2;
-    else if (this.hAlign === 'Right') x = x0 + (w - drawW);
-    if (this.vAlign === 'Center') y = y0 + (h - drawH) / 2;
-    else if (this.vAlign === 'Bottom') y = y0 + (h - drawH);
+    let x = inner.x, y = inner.y;
+    if (this.hAlign === 'Center') x = inner.x + (inner.width - drawW) / 2;
+    else if (this.hAlign === 'Right') x = inner.x + (inner.width - drawW);
+    if (this.vAlign === 'Center') y = inner.y + (inner.height - drawH) / 2;
+    else if (this.vAlign === 'Bottom') y = inner.y + (inner.height - drawH);
 
     this.sprite.setScale(scaleX, scaleY);
     this.sprite.setPosition(x, y);

--- a/packages/runtime/src/elements/Text.ts
+++ b/packages/runtime/src/elements/Text.ts
@@ -1,5 +1,4 @@
-import { UIElement } from '../core.js';
-import type { Size, Rect } from '../core.js';
+import { UIElement, type Size, type Rect } from '@noxigui/core';
 import type { Renderer, RenderText } from '../renderer.js';
 
 export class Text extends UIElement {
@@ -24,20 +23,17 @@ export class Text extends UIElement {
   }
 
   arrange(rect: Rect) {
-    const x0 = rect.x + this.margin.l, y0 = rect.y + this.margin.t;
-    const w = Math.max(0, rect.width - this.margin.l - this.margin.r);
-    const h = Math.max(0, rect.height - this.margin.t - this.margin.b);
-    this.final = { x: x0, y: y0, width: w, height: h };
+    const inner = this.arrangeSelf(rect);
 
     const align = this.hAlign === 'Center' ? 'center' : this.hAlign === 'Right' ? 'right' : 'left';
-    this.text.setWordWrap(Math.max(1, w), align);
+    this.text.setWordWrap(Math.max(1, inner.width), align);
     const b = this.text.getBounds();
 
-    let x = x0, y = y0;
-    if (this.hAlign === 'Center') x = x0 + (w - b.width) / 2;
-    else if (this.hAlign === 'Right') x = x0 + (w - b.width);
-    if (this.vAlign === 'Center') y = y0 + (h - b.height) / 2;
-    else if (this.vAlign === 'Bottom') y = y0 + (h - b.height);
+    let x = inner.x, y = inner.y;
+    if (this.hAlign === 'Center') x = inner.x + (inner.width - b.width) / 2;
+    else if (this.hAlign === 'Right') x = inner.x + (inner.width - b.width);
+    if (this.vAlign === 'Center') y = inner.y + (inner.height - b.height) / 2;
+    else if (this.vAlign === 'Bottom') y = inner.y + (inner.height - b.height);
     this.text.setPosition(x, y);
   }
 }

--- a/packages/runtime/src/helpers.ts
+++ b/packages/runtime/src/helpers.ts
@@ -1,4 +1,4 @@
-import type { UIElement } from './core.js';
+import type { UIElement } from '@noxigui/core';
 import { Grid } from './elements/Grid.js';
 
 export function applyGridAttachedProps(node: Element, el: UIElement) {

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -1,7 +1,6 @@
 import { Parser } from '@noxigui/parser';
+import { UIElement, type Size } from '@noxigui/core';
 import { Grid } from './elements/Grid.js';
-import { UIElement } from './core.js';
-import type { Size } from './core.js';
 import type { Renderer, RenderContainer } from './renderer.js';
 
 export const RuntimeInstance = {


### PR DESCRIPTION
## Summary
- move UIElement base into core and add arrange helper
- make runtime use core UIElement and drop duplicate margin code
- update runtime helpers and runtime instance to import from core

## Testing
- `pnpm -F @noxigui/core test`
- `pnpm -F @noxigui/runtime build`
- `pnpm -F @noxigui/parser build`


------
https://chatgpt.com/codex/tasks/task_e_68b16372275c832aae25769e35d59dfa