### PR TITLE
Add basic runtime and parser tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "scripts": {
     "dev": "node scripts/build-packages.js && pnpm -F @noxigui/playground dev",
-    "build": "node scripts/build-packages.js && pnpm -F @noxigui/playground build"
+    "build": "node scripts/build-packages.js && pnpm -F @noxigui/playground build",
+    "test": "pnpm -r test"
   }
 }

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -2,16 +2,20 @@
   "name": "@noxigui/parser",
   "version": "0.1.0",
   "type": "module",
-  "main": "dist/parser/src/index.js",
-  "types": "dist/parser/src/index.d.ts",
-  "exports": "./dist/parser/src/index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": "./dist/index.js",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "pretest": "pnpm -F @noxigui/runtime build && pnpm run build",
+    "test": "node --test dist/tests/**/*.test.js"
   },
   "dependencies": {
     "@noxigui/runtime": "file:../runtime"
   },
   "devDependencies": {
+    "@types/node": "^20.19.11",
+    "@xmldom/xmldom": "^0.8.11",
     "typescript": "~5.8.3"
   }
 }

--- a/packages/parser/tests/basic.test.ts
+++ b/packages/parser/tests/basic.test.ts
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Parser } from '../src/Parser.js';
+import { Grid, Text } from '@noxigui/runtime';
+import { DOMParser as XmldomParser } from '@xmldom/xmldom';
+
+class PatchedDOMParser extends XmldomParser {
+  parseFromString(str: string, type: string) {
+    const doc = super.parseFromString(str, type);
+    const patch = (el: any) => {
+      el.children = Array.from(el.childNodes || []).filter((c: any) => c.nodeType === 1);
+      el.children.forEach(patch);
+    };
+    patch(doc.documentElement);
+    return doc;
+  }
+}
+
+globalThis.DOMParser = PatchedDOMParser as unknown as typeof globalThis.DOMParser;
+
+const createRenderer = () => {
+  return {
+    getTexture() { return undefined; },
+    createImage() { return {} as any; },
+    createText() {
+      return {
+        setWordWrap() {},
+        getBounds() { return { width: 0, height: 0 }; },
+        setPosition() {},
+        getDisplayObject() { return {}; },
+      } as any;
+    },
+    createGraphics() {
+      return {
+        clear() {},
+        beginFill() { return this; },
+        drawRect() { return this; },
+        endFill() {},
+        destroy() {},
+        getDisplayObject() { return {}; },
+      } as any;
+    },
+    createContainer() {
+      const obj = { children: [] as any[] };
+      return {
+        addChild(child: any) { obj.children.push(child); },
+        removeChild(child: any) {
+          const i = obj.children.indexOf(child);
+          if (i >= 0) obj.children.splice(i, 1);
+        },
+        setPosition() {},
+        setSortableChildren() {},
+        setMask() {},
+        getDisplayObject() { return obj; },
+      } as any;
+    },
+  } as any;
+};
+
+test('parse simple grid with text', () => {
+  const renderer = createRenderer();
+  const parser = new Parser(renderer);
+  const { root, container } = parser.parse('<Grid><TextBlock Text="Hello"/></Grid>');
+  assert.ok(root instanceof Grid);
+  const grid = root as Grid;
+  assert.equal(grid.children.length, 1);
+  const child = grid.children[0];
+  assert.ok(child instanceof Text);
+  assert.ok(container.getDisplayObject().children.length >= 1);
+});

--- a/packages/parser/tsconfig.json
+++ b/packages/parser/tsconfig.json
@@ -9,7 +9,10 @@
     "baseUrl": "src",
     "paths": {
       "@noxigui/runtime": ["../../runtime/dist/runtime/src/index.d.ts"]
-    }
+    },
+    "moduleResolution": "node",
+    "types": ["node"],
+    "allowSyntheticDefaultImports": true
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "tsc -p tsconfig.json && node --test dist/runtime/tests/**/*.test.js",
+    "pretest": "pnpm run build",
+    "test": "node --test dist/runtime/tests/**/*.test.js",
     "prepare": "pnpm run build"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
         specifier: file:../runtime
         version: file:packages/runtime
     devDependencies:
+      '@types/node':
+        specifier: ^20.19.11
+        version: 20.19.11
+      '@xmldom/xmldom':
+        specifier: ^0.8.11
+        version: 0.8.11
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -703,6 +709,10 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@xmldom/xmldom@0.8.11':
+    resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
+    engines: {node: '>=10.0.0'}
 
   browserslist@4.25.4:
     resolution: {integrity: sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==}
@@ -1510,6 +1520,8 @@ snapshots:
       vite: 6.3.5(@types/node@20.19.11)
     transitivePeerDependencies:
       - supports-color
+
+  '@xmldom/xmldom@0.8.11': {}
 
   browserslist@4.25.4:
     dependencies:


### PR DESCRIPTION
## Summary
- run tests for all packages via new workspace script
- add parser XML parsing test and DOMParser polyfill
- use pretest hooks and node's test runner for runtime and parser packages

## Testing
- `pnpm -r --workspace-concurrency=1 test`


------
https://chatgpt.com/codex/tasks/task_e_68b16a8c60bc832ab7a1b021a0617a23