### PR TITLE
feat: inject XML parser dependency

### DIFF
--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -13,7 +13,8 @@ pnpm add @noxigui/parser pixi.js
 ```ts
 import { Parser } from '@noxigui/parser';
 
-const parser = new Parser();
+// supply a renderer and optionally an XML parser implementation
+const parser = new Parser(renderer, new DOMParser());
 const { root, container } = parser.parse('<Grid></Grid>');
 ```
 
@@ -32,7 +33,18 @@ class MyParser implements ElementParser {
   parse(node: Element, p: Parser) { /* ... */ return null; }
 }
 
-const parser = new Parser([new MyParser()]);
+const parser = new Parser(renderer, new DOMParser(), [new MyParser()]);
+```
+
+### Node.js
+
+In Node environments, provide an XML parser such as `@xmldom/xmldom`:
+
+```ts
+import { DOMParser } from '@xmldom/xmldom';
+import { Parser } from '@noxigui/parser';
+
+const parser = new Parser(renderer, new DOMParser());
 ```
 
 Custom parsers can also participate in assembling the PIXI display tree by

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -2,16 +2,16 @@
   "name": "@noxigui/parser",
   "version": "0.1.0",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "exports": "./dist/index.js",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "exports": "./dist/src/index.js",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "pretest": "pnpm -F @noxigui/runtime build && pnpm run build",
     "test": "node --test dist/tests/**/*.test.js"
   },
   "dependencies": {
-    "@noxigui/runtime": "file:../runtime"
+    "@noxigui/runtime": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^20.19.11",

--- a/packages/parser/src/Parser.ts
+++ b/packages/parser/src/Parser.ts
@@ -2,6 +2,10 @@ import { UIElement } from '@noxigui/runtime';
 import { parsers as elementParsers } from './parsers/index.js';
 import type { Renderer, RenderContainer } from '@noxigui/runtime';
 
+export interface XmlParser {
+  parseFromString(xml: string, type: string): Document;
+}
+
 /**
  * Parses NoxiGUI XML markup into UI elements and a PIXI display tree.
  */
@@ -11,7 +15,11 @@ export class Parser {
    *
    * @param parsers - Registered element parsers. Defaults to built-in parsers.
    */
-  constructor(public renderer: Renderer, private parsers = elementParsers) {}
+  constructor(
+    public renderer: Renderer,
+    private xmlParser: XmlParser = new DOMParser(),
+    private parsers = elementParsers,
+  ) {}
 
   /**
    * Parse a single DOM element using the first parser that matches it.
@@ -35,7 +43,7 @@ export class Parser {
    * @returns Object containing the root UI element and the root render container.
    */
   parse(xml: string) {
-    const dom = new DOMParser().parseFromString(xml, 'application/xml');
+    const dom = this.xmlParser.parseFromString(xml, 'application/xml');
     const rootEl = dom.documentElement;
     if (rootEl.tagName !== 'Grid') throw new Error('Root must be <Grid>');
 

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -2,3 +2,4 @@
  * Entry point for the `@noxigui/parser` package.
  */
 export { Parser } from './Parser.js';
+export type { XmlParser } from './Parser.js';

--- a/packages/parser/tests/basic.test.ts
+++ b/packages/parser/tests/basic.test.ts
@@ -16,8 +16,6 @@ class PatchedDOMParser extends XmldomParser {
   }
 }
 
-globalThis.DOMParser = PatchedDOMParser as unknown as typeof globalThis.DOMParser;
-
 const createRenderer = () => {
   return {
     getTexture() { return undefined; },
@@ -59,7 +57,7 @@ const createRenderer = () => {
 
 test('parse simple grid with text', () => {
   const renderer = createRenderer();
-  const parser = new Parser(renderer);
+  const parser = new Parser(renderer, new PatchedDOMParser());
   const { root, container } = parser.parse('<Grid><TextBlock Text="Hello"/></Grid>');
   assert.ok(root instanceof Grid);
   const grid = root as Grid;

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "pixi.js": "^7.4.3",
-    "@noxigui/core": "file:../core",
+    "@noxigui/core": "workspace:*",
     "@noxigui/parser": "workspace:*"
   },
   "devDependencies": {

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -10,8 +10,8 @@
     "paths": {
       "@noxigui/core": ["../../core/dist/src/index.d.ts"],
       "@noxigui/core/*": ["../../core/dist/src/*"],
-      "@noxigui/parser": ["../../parser/src/index.ts"],
-      "@noxigui/parser/*": ["../../parser/src/*"],
+      "@noxigui/parser": ["../../parser/dist/src/index.d.ts"],
+      "@noxigui/parser/*": ["../../parser/dist/src/*"],
       "@noxigui/runtime": ["./index.ts"],
       "@noxigui/runtime/*": ["./*"]
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
   packages/parser:
     dependencies:
       '@noxigui/runtime':
-        specifier: file:../runtime
-        version: file:packages/runtime
+        specifier: workspace:*
+        version: link:../runtime
     devDependencies:
       '@types/node':
         specifier: ^20.19.11
@@ -89,7 +89,7 @@ importers:
   packages/runtime:
     dependencies:
       '@noxigui/core':
-        specifier: file:../core
+        specifier: workspace:*
         version: link:../core
       '@noxigui/parser':
         specifier: workspace:*
@@ -362,9 +362,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.30':
     resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
-
-  '@noxigui/core@file:packages/core':
-    resolution: {directory: packages/core, type: directory}
 
   '@noxigui/runtime@file:packages/runtime':
     resolution: {directory: packages/runtime, type: directory}
@@ -1210,11 +1207,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@noxigui/core@file:packages/core': {}
-
   '@noxigui/runtime@file:packages/runtime':
     dependencies:
-      '@noxigui/core': file:packages/core
+      '@noxigui/core': link:packages/core
       '@noxigui/parser': link:packages/parser
       pixi.js: 7.4.3
 


### PR DESCRIPTION
## Summary
- allow supplying a custom XML parser implementation
- switch runtime and parser to workspace dependencies and built artifacts
- document XML parser injection and Node usage

## Testing
- `pnpm -F @noxigui/runtime test`
- `pnpm -F @noxigui/parser test`


------
https://chatgpt.com/codex/tasks/task_e_68b15b5042b8832a8d94b1544e0c5d87