### PR TITLE
feat: add GuiObject class

### DIFF
--- a/noxi.js
+++ b/noxi.js
@@ -1,0 +1,12 @@
+// @ts-check
+import { RuntimeInstance } from './packages/runtime/src/index.js';
+
+/**
+ * Create GUI object from markup.
+ * @param {string} xml - XML markup starting with <Grid> root.
+ * @param {import('./packages/runtime/src/renderer.js').Renderer} renderer - Renderer implementation.
+ * @returns {import('./packages/runtime/src/GuiObject.js').GuiObject}
+ */
+export function createGui(xml, renderer) {
+  return RuntimeInstance.create(xml, renderer);
+}

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "typescript": "~5.8.3",
-    "@types/node": "^20.11.30"
+    "@types/node": "^20.11.30",
+    "@xmldom/xmldom": "^0.8.11"
   }
 }

--- a/packages/runtime/src/GuiObject.ts
+++ b/packages/runtime/src/GuiObject.ts
@@ -1,0 +1,28 @@
+import type { Size, UIElement } from '@noxigui/core';
+import { Grid } from './elements/Grid.js';
+import type { RenderContainer } from './renderer.js';
+
+export class GuiObject {
+  constructor(private root: UIElement, public container: RenderContainer) {}
+
+  layout(size: Size) {
+    this.root.measure(size);
+    this.root.arrange({ x: 0, y: 0, width: size.width, height: size.height });
+  }
+
+  destroy() {
+    const obj = this.container.getDisplayObject();
+    (obj as any)?.destroy?.({ children: true });
+  }
+
+  setGridDebug(on: boolean) {
+    const visit = (u: UIElement, f: (g: Grid) => void) => {
+      if (u instanceof Grid) f(u);
+      const kids = (u as any).children as UIElement[] | undefined;
+      if (kids) kids.forEach(k => visit(k, f));
+      const child = (u as any).child as UIElement | undefined;
+      if (child) visit(child, f);
+    };
+    visit(this.root, g => { g.debug = on; });
+  }
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -9,3 +9,4 @@ export { measureGrid, arrangeGrid } from './elements/grid/layout.js';
 export * from './helpers.js';
 export type { Renderer, RenderImage, RenderText, RenderGraphics, RenderContainer } from './renderer.js';
 export { RuntimeInstance } from './runtime.js';
+export { GuiObject } from './GuiObject.js';

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -1,36 +1,10 @@
 import { Parser } from '@noxigui/parser';
-import { UIElement, type Size } from '@noxigui/core';
-import { Grid } from './elements/Grid.js';
-import type { Renderer, RenderContainer } from './renderer.js';
+import type { Renderer } from './renderer.js';
+import { GuiObject } from './GuiObject.js';
 
 export const RuntimeInstance = {
   create(xml: string, renderer: Renderer) {
     const { root, container } = new Parser(renderer).parse(xml);
-
-    const visit = (u: UIElement, f: (g: Grid) => void) => {
-      if (u instanceof Grid) f(u);
-      const kids = (u as any).children as UIElement[] | undefined;
-      if (kids) kids.forEach(k => visit(k, f));
-      const child = (u as any).child as UIElement | undefined;
-      if (child) visit(child, f);
-    };
-    const setGridDebug = (on: boolean) => visit(root, g => { g.debug = on; });
-
-    const layout = (size: Size) => {
-      root.measure(size);
-      root.arrange({ x: 0, y: 0, width: size.width, height: size.height });
-    };
-
-    const destroy = () => {
-      const obj = container.getDisplayObject();
-      (obj as any)?.destroy?.({ children: true });
-    };
-
-    return { container, layout, destroy, setGridDebug } as {
-      container: RenderContainer;
-      layout: (size: Size) => void;
-      destroy: () => void;
-      setGridDebug: (on: boolean) => void;
-    };
+    return new GuiObject(root, container);
   }
 };

--- a/packages/runtime/tests/runtime-instance.test.ts
+++ b/packages/runtime/tests/runtime-instance.test.ts
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { RuntimeInstance, type GuiObject } from '../src/index.js';
+import type { Renderer, RenderGraphics, RenderContainer } from '../src/renderer.js';
+import { DOMParser as XmldomParser } from '@xmldom/xmldom';
+
+class PatchedDOMParser extends XmldomParser {
+  parseFromString(str: string, type: string) {
+    const doc = super.parseFromString(str, type);
+    const patch = (el: any) => {
+      el.children = Array.from(el.childNodes || []).filter((c: any) => c.nodeType === 1);
+      el.children.forEach(patch);
+    };
+    patch(doc.documentElement);
+    return doc;
+  }
+}
+
+(globalThis as any).DOMParser = PatchedDOMParser;
+
+const graphicsObj: any = {
+  visible: false,
+  clear() {},
+  lineStyle() {},
+  drawRect() {},
+  beginFill() {},
+  endFill() {},
+  moveTo() {},
+  lineTo() {},
+};
+
+const gfx: RenderGraphics = {
+  clear() {},
+  beginFill() { return this; },
+  drawRect() { return this; },
+  endFill() {},
+  destroy() {},
+  getDisplayObject() { return graphicsObj; },
+};
+
+const containerObj: any = {
+  addChild() {},
+  removeChild() {},
+  setPosition() {},
+  setSortableChildren() {},
+  setMask() {},
+  destroy() { this.destroyed = true; },
+  getDisplayObject() { return this; },
+};
+
+const renderer: Renderer = {
+  getTexture() { return undefined; },
+  createImage() { return {} as any; },
+  createText() { return {} as any; },
+  createGraphics() { return gfx; },
+  createContainer() { return containerObj as RenderContainer; },
+};
+
+test('RuntimeInstance.create returns GuiObject', () => {
+  const xml = '<Grid />';
+  const gui: GuiObject = RuntimeInstance.create(xml, renderer);
+  assert.equal(gui.container, containerObj);
+  gui.layout({ width: 100, height: 100 });
+  gui.setGridDebug(true);
+  gui.destroy();
+  assert.equal(containerObj.destroyed, true);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       '@types/node':
         specifier: ^20.11.30
         version: 20.19.11
+      '@xmldom/xmldom':
+        specifier: ^0.8.11
+        version: 0.8.11
       typescript:
         specifier: ~5.8.3
         version: 5.8.3


### PR DESCRIPTION
## Summary
- add GuiObject class encapsulating layout, destroy and grid debug helpers
- return GuiObject from RuntimeInstance.create and export through runtime API
- add runtime-instance test and sample noxi.js using GuiObject

## Testing
- `npm test` (runtime tests not picked up)
- `node --test packages/runtime/dist/tests/*.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b17f440f18832ab67796262daf5935