### PR TITLE
feat: isolate templates per gui instance

### DIFF
--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -12,9 +12,10 @@ pnpm add @noxigui/parser pixi.js
 
 ```ts
 import { Parser } from '@noxigui/parser';
+import { TemplateStore } from '@noxigui/runtime';
 
-// supply a renderer and optionally an XML parser implementation
-const parser = new Parser(renderer, new DOMParser());
+// supply a renderer, a template store and optionally an XML parser implementation
+const parser = new Parser(renderer, new TemplateStore(), new DOMParser());
 const { root, container } = parser.parse('<Grid></Grid>');
 ```
 
@@ -27,13 +28,14 @@ it to the `Parser` constructor:
 ```ts
 import type { ElementParser } from '@noxigui/parser';
 import { Parser } from '@noxigui/parser';
+import { TemplateStore } from '@noxigui/runtime';
 
 class MyParser implements ElementParser {
   test(node: Element) { return node.tagName === 'MyElement'; }
   parse(node: Element, p: Parser) { /* ... */ return null; }
 }
 
-const parser = new Parser(renderer, new DOMParser(), [new MyParser()]);
+const parser = new Parser(renderer, new TemplateStore(), new DOMParser(), [new MyParser()]);
 ```
 
 ### Node.js
@@ -43,8 +45,9 @@ In Node environments, provide an XML parser such as `@xmldom/xmldom`:
 ```ts
 import { DOMParser } from '@xmldom/xmldom';
 import { Parser } from '@noxigui/parser';
+import { TemplateStore } from '@noxigui/runtime';
 
-const parser = new Parser(renderer, new DOMParser());
+const parser = new Parser(renderer, new TemplateStore(), new DOMParser());
 ```
 
 Custom parsers can also participate in assembling the PIXI display tree by

--- a/packages/parser/src/Parser.ts
+++ b/packages/parser/src/Parser.ts
@@ -1,5 +1,5 @@
-import { UIElement } from '@noxigui/runtime';
-import { parsers as elementParsers } from './parsers/index.js';
+import { UIElement, TemplateStore } from '@noxigui/runtime';
+import { createParsers as elementParsers } from './parsers/index.js';
 import type { Renderer, RenderContainer } from '@noxigui/runtime';
 
 export interface XmlParser {
@@ -17,8 +17,9 @@ export class Parser {
    */
   constructor(
     public renderer: Renderer,
+    public templates: TemplateStore,
     private xmlParser: XmlParser = new DOMParser(),
-    private parsers = elementParsers,
+    private parsers = elementParsers(templates),
   ) {}
 
   /**

--- a/packages/parser/src/parsers/ResourcesParser.ts
+++ b/packages/parser/src/parsers/ResourcesParser.ts
@@ -1,13 +1,14 @@
-import { registerTemplate } from '@noxigui/runtime';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
+import type { TemplateStore } from '@noxigui/runtime';
 
 /** Parser for `<Resources>` blocks. */
 export class ResourcesParser implements ElementParser {
+  constructor(private templates: TemplateStore) {}
   test(node: Element): boolean { return node.tagName === 'Resources'; }
   parse(node: Element, _p: Parser) {
     for (const ch of Array.from(node.children)) {
-      if (ch.tagName === 'Template') registerTemplate(ch);
+      if (ch.tagName === 'Template') this.templates.register(ch);
     }
     return null;
   }

--- a/packages/parser/src/parsers/UseParser.ts
+++ b/packages/parser/src/parsers/UseParser.ts
@@ -1,9 +1,10 @@
-import { instantiateTemplate } from '@noxigui/runtime';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
+import type { TemplateStore } from '@noxigui/runtime';
 
 /** Parser for `<Use>` elements that instantiate templates. */
 export class UseParser implements ElementParser {
+  constructor(private templates: TemplateStore) {}
   test(node: Element): boolean { return node.tagName === 'Use'; }
   parse(node: Element, p: Parser) {
     const key = node.getAttribute('Template') || '';
@@ -18,7 +19,7 @@ export class UseParser implements ElementParser {
         slotMap.set(name, content);
       }
     }
-    const rootEl = instantiateTemplate(key, props, slotMap);
+    const rootEl = this.templates.instantiate(key, props, slotMap);
 
     const gr = node.getAttribute('Grid.Row');         if (gr)  rootEl.setAttribute('Grid.Row', gr);
     const gc = node.getAttribute('Grid.Column');      if (gc)  rootEl.setAttribute('Grid.Column', gc);

--- a/packages/parser/src/parsers/index.ts
+++ b/packages/parser/src/parsers/index.ts
@@ -15,13 +15,14 @@ import { ResourcesParser } from './ResourcesParser.js';
 import { ContentPresenterParser } from './ContentPresenterParser.js';
 import { UseParser } from './UseParser.js';
 import type { ElementParser } from './ElementParser.js';
+import type { TemplateStore } from '@noxigui/runtime';
 
-export const parsers: ElementParser[] = [
+export const createParsers = (templates: TemplateStore): ElementParser[] => [
   new TextBlockParser(),
   new BorderParser(),
   new GridParser(),
   new ImageParser(),
-  new ResourcesParser(),
+  new ResourcesParser(templates),
   new ContentPresenterParser(),
-  new UseParser(),
+  new UseParser(templates),
 ];

--- a/packages/parser/tests/basic.test.ts
+++ b/packages/parser/tests/basic.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Parser } from '../src/Parser.js';
-import { Grid, Text } from '@noxigui/runtime';
+import { Grid, Text, TemplateStore } from '@noxigui/runtime';
 import { DOMParser as XmldomParser } from '@xmldom/xmldom';
 
 class PatchedDOMParser extends XmldomParser {
@@ -57,7 +57,7 @@ const createRenderer = () => {
 
 test('parse simple grid with text', () => {
   const renderer = createRenderer();
-  const parser = new Parser(renderer, new PatchedDOMParser());
+  const parser = new Parser(renderer, new TemplateStore(), new PatchedDOMParser());
   const { root, container } = parser.parse('<Grid><TextBlock Text="Hello"/></Grid>');
   assert.ok(root instanceof Grid);
   const grid = root as Grid;

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "pretest": "pnpm run build",
-    "test": "if ls dist/runtime/tests/**/*.test.js 1> /dev/null 2>&1; then node --test dist/runtime/tests/**/*.test.js; else echo 'no tests'; fi"
+    "test": "if ls dist/tests/*.test.js 1> /dev/null 2>&1; then node --test dist/tests/*.test.js; else echo 'no tests'; fi"
   },
   "dependencies": {
     "pixi.js": "^7.4.3",

--- a/packages/runtime/src/GuiObject.ts
+++ b/packages/runtime/src/GuiObject.ts
@@ -1,9 +1,20 @@
 import type { Size, UIElement } from '@noxigui/core';
 import { Grid } from './elements/Grid.js';
-import type { RenderContainer } from './renderer.js';
+import type { Renderer, RenderContainer } from './renderer.js';
+import { Parser } from '@noxigui/parser';
+import { TemplateStore } from './template.js';
 
 export class GuiObject {
-  constructor(private root: UIElement, public container: RenderContainer) {}
+  public root: UIElement;
+  public container: RenderContainer;
+  public templates: TemplateStore;
+
+  constructor(xml: string, renderer: Renderer) {
+    this.templates = new TemplateStore();
+    const { root, container } = new Parser(renderer, this.templates).parse(xml);
+    this.root = root;
+    this.container = container;
+  }
 
   layout(size: Size) {
     this.root.measure(size);

--- a/packages/runtime/src/parser-shim.d.ts
+++ b/packages/runtime/src/parser-shim.d.ts
@@ -1,9 +1,10 @@
 import type { UIElement } from '@noxigui/core'
 import type { Renderer, RenderContainer } from './renderer.js'
+import type { TemplateStore } from './template.js'
 
 declare module '@noxigui/parser' {
   class Parser {
-    constructor(renderer: Renderer)
+    constructor(renderer: Renderer, templates: TemplateStore)
     parse(xml: string): { root: UIElement; container: RenderContainer }
   }
   export { Parser }

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -1,10 +1,8 @@
-import { Parser } from '@noxigui/parser';
 import type { Renderer } from './renderer.js';
 import { GuiObject } from './GuiObject.js';
 
 export const RuntimeInstance = {
   create(xml: string, renderer: Renderer) {
-    const { root, container } = new Parser(renderer).parse(xml);
-    return new GuiObject(root, container);
+    return new GuiObject(xml, renderer);
   }
 };

--- a/packages/runtime/src/template.ts
+++ b/packages/runtime/src/template.ts
@@ -1,52 +1,55 @@
 // Template registry utilities
 
-const TemplateRegistry = new Map<string, Element>();
-
-export function registerTemplate(node: Element) {
-  const key = node.getAttribute('Key') || node.getAttribute('x:Key');
-  if (!key) throw new Error('<Template> needs Key');
-  const root = Array.from(node.children).find(ch => ch.nodeType === 1) as Element | undefined;
-  if (!root) throw new Error('<Template> must have a single root element');
-  TemplateRegistry.set(key, root.cloneNode(true) as Element);
-}
-
 function subst(value: string, props: Record<string, string>): string {
   return value.replace(/\{([\w.-]+)\}/g, (_, name) => props[name] ?? '');
 }
 
-export function instantiateTemplate(
-  key: string,
-  props: Record<string, string>,
-  slotNodes: Map<string, Element[]>
-): Element {
-  const tplRoot = TemplateRegistry.get(key);
-  if (!tplRoot) throw new Error(`Template not found: ${key}`);
-  const clone = tplRoot.cloneNode(true) as Element;
-
-  // substitute placeholders
-  const walkAttrs = (el: Element) => {
-    for (const attr of Array.from(el.attributes)) attr.value = subst(attr.value, props);
-    for (const ch of Array.from(el.children)) walkAttrs(ch);
-  };
-  walkAttrs(clone);
-
-  // fill slots
-  const fillSlots = (el: Element) => {
-    if (el.tagName === 'ContentPresenter') {
-      const name = el.getAttribute('Slot') ?? '';
-      const provided = slotNodes.get(name);
-      if (provided && provided.length) {
-        const parent = el.parentElement!;
-        for (const node of provided) parent.insertBefore(node.cloneNode(true), el);
-        parent.removeChild(el);
-        return;
-      }
-    }
-    for (const ch of Array.from(el.children)) fillSlots(ch);
-  };
-  fillSlots(clone);
-
-  return clone;
+function childrenOf(el: Element): Element[] {
+  const kids = (el as any).children as Element[] | undefined;
+  return kids ? Array.from(kids) : Array.from((el.childNodes || [])).filter((c: any) => c.nodeType === 1) as Element[];
 }
 
-export { TemplateRegistry };
+export class TemplateStore {
+  private registry = new Map<string, Element>();
+
+  register(node: Element) {
+    const key = node.getAttribute('Key') || node.getAttribute('x:Key');
+    if (!key) throw new Error('<Template> needs Key');
+    const root = childrenOf(node).find(ch => ch.nodeType === 1);
+    if (!root) throw new Error('<Template> must have a single root element');
+    this.registry.set(key, root.cloneNode(true) as Element);
+  }
+
+  instantiate(key: string, props: Record<string, string>, slotNodes: Map<string, Element[]>): Element {
+    const tplRoot = this.registry.get(key);
+    if (!tplRoot) throw new Error(`Template not found: ${key}`);
+    const clone = tplRoot.cloneNode(true) as Element;
+
+    const walkAttrs = (el: Element) => {
+      for (const attr of Array.from(el.attributes)) attr.value = subst(attr.value, props);
+      for (const ch of childrenOf(el)) walkAttrs(ch);
+    };
+    walkAttrs(clone);
+
+    const fillSlots = (el: Element) => {
+      if (el.tagName === 'ContentPresenter') {
+        const name = el.getAttribute('Slot') ?? '';
+        const provided = slotNodes.get(name);
+        if (provided && provided.length) {
+          const parent = el.parentElement!;
+          for (const node of provided) parent.insertBefore(node.cloneNode(true), el);
+          parent.removeChild(el);
+          return;
+        }
+      }
+      for (const ch of childrenOf(el)) fillSlots(ch);
+    };
+    fillSlots(clone);
+
+    return clone;
+  }
+
+  clear() {
+    this.registry.clear();
+  }
+}

--- a/packages/runtime/tests/template-isolation.test.ts
+++ b/packages/runtime/tests/template-isolation.test.ts
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { RuntimeInstance } from '../src/index.js';
+import type { Renderer, RenderContainer } from '../src/renderer.js';
+import { DOMParser as XmldomParser } from '@xmldom/xmldom';
+
+class PatchedDOMParser extends XmldomParser {
+  parseFromString(str: string, type: string) {
+    const doc = super.parseFromString(str, type);
+    const patch = (el: any) => {
+      el.children = Array.from(el.childNodes || []).filter((c: any) => c.nodeType === 1);
+      el.children.forEach(patch);
+    };
+    patch(doc.documentElement);
+    return doc;
+  }
+}
+
+(globalThis as any).DOMParser = PatchedDOMParser;
+
+const graphicsObj: any = {
+  visible: false,
+  clear() {},
+  lineStyle() {},
+  drawRect() {},
+  beginFill() {},
+  endFill() {},
+  moveTo() {},
+  lineTo() {},
+};
+
+const gfx = {
+  clear() {},
+  beginFill() { return this; },
+  drawRect() { return this; },
+  endFill() {},
+  destroy() {},
+  getDisplayObject() { return graphicsObj; },
+};
+
+const containerObj: any = {
+  addChild() {},
+  removeChild() {},
+  setPosition() {},
+  setSortableChildren() {},
+  setMask() {},
+  destroy() { this.destroyed = true; },
+  getDisplayObject() { return this; },
+};
+
+const renderer: Renderer = {
+  getTexture() { return undefined; },
+  createImage() { return {} as any; },
+  createText(content: string) {
+    return {
+      content,
+      setWordWrap() {},
+      getBounds() { return { width: 0, height: 0 }; },
+      setPosition() {},
+      getDisplayObject() { return { content }; },
+    } as any;
+  },
+  createGraphics() { return gfx as any; },
+  createContainer() { return containerObj as RenderContainer; },
+};
+
+test('templates are isolated between GuiObject instances', () => {
+  const xmlA = '<Grid><Resources><Template Key="T"><TextBlock Text="One"/></Template></Resources><Use Template="T"/></Grid>';
+  const xmlB = '<Grid><Resources><Template Key="T"><TextBlock Text="Two"/></Template></Resources><Use Template="T"/></Grid>';
+
+  const guiA = RuntimeInstance.create(xmlA, renderer);
+  const guiB = RuntimeInstance.create(xmlB, renderer);
+
+  const textA = (guiA.root as any).children[0];
+  const textB = (guiB.root as any).children[0];
+
+  assert.equal((textA.text as any).content, 'One');
+  assert.equal((textB.text as any).content, 'Two');
+});


### PR DESCRIPTION
## Summary
- add `TemplateStore` for managing templates and instantiation
- wire parser and runtime to use per-GuiObject template stores
- test isolation of templates between GuiObject instances

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1813a082c832a8d4390edd7c86f5c