### PR TITLE
feat: add noxi.js package

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ This repository is a monorepo containing:
 - `@noxigui/playground` – a Vite playground for experimenting with the runtime.
 
 Run `pnpm dev` to start the playground or `pnpm build` to build all packages.
+
+```ts
+import Noxi from "noxi.js";
+```

--- a/packages/noxi.js/dist/index.cjs
+++ b/packages/noxi.js/dist/index.cjs
@@ -1,0 +1,11 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const runtime_1 = require("@noxigui/runtime");
+const Noxi = {
+    gui: {
+        create(xml, renderer) {
+            return runtime_1.RuntimeInstance.create(xml, renderer);
+        }
+    }
+};
+exports.default = Noxi;

--- a/packages/noxi.js/dist/index.d.ts
+++ b/packages/noxi.js/dist/index.d.ts
@@ -1,0 +1,8 @@
+import { type GuiObject, type Renderer } from '@noxigui/runtime';
+declare const Noxi: {
+    gui: {
+        create(xml: string, renderer?: Renderer): GuiObject;
+    };
+};
+export default Noxi;
+//# sourceMappingURL=index.d.ts.map

--- a/packages/noxi.js/dist/index.d.ts.map
+++ b/packages/noxi.js/dist/index.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":"AAAA,OAAO,EAAmB,KAAK,SAAS,EAAE,KAAK,QAAQ,EAAE,MAAM,kBAAkB,CAAC;AAElF,QAAA,MAAM,IAAI;;oBAEM,MAAM,aAAa,QAAQ,GAAG,SAAS;;CAItD,CAAC;AAEF,eAAe,IAAI,CAAC"}

--- a/packages/noxi.js/package.json
+++ b/packages/noxi.js/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "noxi.js",
+  "version": "0.1.0",
+  "main": "dist/index.cjs",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json && mv dist/index.js dist/index.cjs"
+  },
+  "dependencies": {
+    "@noxigui/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "~5.8.3",
+    "@types/node": "^20.11.30"
+  }
+}

--- a/packages/noxi.js/src/index.ts
+++ b/packages/noxi.js/src/index.ts
@@ -1,0 +1,11 @@
+import { RuntimeInstance, type GuiObject, type Renderer } from '@noxigui/runtime';
+
+const Noxi = {
+  gui: {
+    create(xml: string, renderer?: Renderer): GuiObject {
+      return RuntimeInstance.create(xml, renderer as Renderer);
+    }
+  }
+};
+
+export default Noxi;

--- a/packages/noxi.js/tsconfig.json
+++ b/packages/noxi.js/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "allowImportingTsExtensions": false,
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "verbatimModuleSyntax": false,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,19 @@ importers:
         specifier: ~5.8.3
         version: 5.8.3
 
+  packages/noxi.js:
+    dependencies:
+      '@noxigui/runtime':
+        specifier: workspace:*
+        version: link:../runtime
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.19.11
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+
   packages/parser:
     dependencies:
       '@noxigui/runtime':

--- a/scripts/build-packages.js
+++ b/scripts/build-packages.js
@@ -18,10 +18,12 @@ const packages = packageDirs
   })
   .filter((pkg) => pkg.name !== '@noxigui/playground');
 
+const packageNames = new Set(packages.map((p) => p.name));
+
 // Build dependency graph and perform topological sort
 const graph = new Map();
 for (const pkg of packages) {
-  let deps = Object.keys(pkg.deps || {}).filter((dep) => dep.startsWith('@noxigui/'));
+  let deps = Object.keys(pkg.deps || {}).filter((dep) => packageNames.has(dep));
   // runtime can import parser for optional features but doesn't require it
   // to be built beforehand. Avoid including this edge in the build graph to
   // prevent a circular dependency during topological sorting (parser -> runtime


### PR DESCRIPTION
## Summary
- add `noxi.js` package exporting a Noxi gui helper
- document Noxi usage
- support building unscoped packages in build script

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b183e491dc832a9ba319d422d7a8b4