### PR TITLE
feat: default to pixi renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ Run `pnpm dev` to start the playground or `pnpm build` to build all packages.
 
 ```ts
 import Noxi from "noxi.js";
+const gui = Noxi.gui.create(xml); // uses PIXI.js renderer by default
 ```

--- a/packages/noxi.js/package.json
+++ b/packages/noxi.js/package.json
@@ -7,7 +7,8 @@
     "build": "tsc -p tsconfig.json && mv dist/index.js dist/index.cjs"
   },
   "dependencies": {
-    "@noxigui/runtime": "workspace:*"
+    "@noxigui/runtime": "workspace:*",
+    "@noxigui/renderer-pixi": "workspace:*"
   },
   "devDependencies": {
     "typescript": "~5.8.3",

--- a/packages/noxi.js/src/index.ts
+++ b/packages/noxi.js/src/index.ts
@@ -1,9 +1,10 @@
 import { RuntimeInstance, type GuiObject, type Renderer } from '@noxigui/runtime';
+import { createPixiRenderer } from '@noxigui/renderer-pixi';
 
 const Noxi = {
   gui: {
-    create(xml: string, renderer?: Renderer): GuiObject {
-      return RuntimeInstance.create(xml, renderer as Renderer);
+    create(xml: string, renderer: Renderer = createPixiRenderer()): GuiObject {
+      return RuntimeInstance.create(xml, renderer);
     }
   }
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
 
   packages/noxi.js:
     dependencies:
+      '@noxigui/renderer-pixi':
+        specifier: workspace:*
+        version: link:../renderer-pixi
       '@noxigui/runtime':
         specifier: workspace:*
         version: link:../runtime


### PR DESCRIPTION
## Summary
- default Noxi.gui.create to PIXI.js renderer
- document default renderer in README

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b18aeed87c832a89b89ea9ac7567ad