### PR TITLE
refactor(runtime): inject parser dependency

### DIFF
--- a/noxi.js
+++ b/noxi.js
@@ -1,5 +1,6 @@
 // @ts-check
 import { RuntimeInstance } from './packages/runtime/src/index.js';
+import { Parser } from './packages/parser/src/index.js';
 
 /**
  * Create GUI object from markup.
@@ -8,5 +9,5 @@ import { RuntimeInstance } from './packages/runtime/src/index.js';
  * @returns {import('./packages/runtime/src/GuiObject.js').GuiObject}
  */
 export function createGui(xml, renderer) {
-  return RuntimeInstance.create(xml, renderer);
+  return RuntimeInstance.create(xml, renderer, Parser);
 }

--- a/packages/noxi.js/package.json
+++ b/packages/noxi.js/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "@noxigui/runtime": "workspace:*",
-    "@noxigui/renderer-pixi": "workspace:*"
+    "@noxigui/renderer-pixi": "workspace:*",
+    "@noxigui/parser": "workspace:*"
   },
   "devDependencies": {
     "typescript": "~5.8.3",

--- a/packages/noxi.js/src/index.ts
+++ b/packages/noxi.js/src/index.ts
@@ -1,10 +1,11 @@
 import { RuntimeInstance, type GuiObject, type Renderer } from '@noxigui/runtime';
 import { createPixiRenderer } from '@noxigui/renderer-pixi';
+import { Parser } from '@noxigui/parser';
 
 const Noxi = {
   gui: {
     create(xml: string, renderer: Renderer = createPixiRenderer()): GuiObject {
-      return RuntimeInstance.create(xml, renderer);
+      return RuntimeInstance.create(xml, renderer, Parser);
     }
   }
 };

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -13,17 +13,17 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "pretest": "pnpm run build",
+    "pretest": "pnpm run build && pnpm -F @noxigui/parser build",
     "test": "if ls dist/tests/*.test.js 1> /dev/null 2>&1; then node --test dist/tests/*.test.js; else echo 'no tests'; fi"
   },
   "dependencies": {
     "pixi.js": "^7.4.3",
-    "@noxigui/core": "workspace:*",
-    "@noxigui/parser": "workspace:*"
+    "@noxigui/core": "workspace:*"
   },
   "devDependencies": {
     "typescript": "~5.8.3",
     "@types/node": "^20.11.30",
-    "@xmldom/xmldom": "^0.8.11"
+    "@xmldom/xmldom": "^0.8.11",
+    "@noxigui/parser": "workspace:*"
   }
 }

--- a/packages/runtime/src/GuiObject.ts
+++ b/packages/runtime/src/GuiObject.ts
@@ -1,15 +1,20 @@
 import type { Size, UIElement } from '@noxigui/core';
 import { Grid } from './elements/Grid.js';
 import type { Renderer, RenderContainer } from './renderer.js';
-import { Parser } from '@noxigui/parser';
 import { TemplateStore } from './template.js';
+
+export interface ParserCtor {
+  new (renderer: Renderer, templates: TemplateStore): {
+    parse(xml: string): { root: UIElement; container: RenderContainer };
+  };
+}
 
 export class GuiObject {
   public root: UIElement;
   public container: RenderContainer;
   public templates: TemplateStore;
 
-  constructor(xml: string, renderer: Renderer) {
+  constructor(xml: string, renderer: Renderer, Parser: ParserCtor) {
     this.templates = new TemplateStore();
     const { root, container } = new Parser(renderer, this.templates).parse(xml);
     this.root = root;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -9,4 +9,4 @@ export { measureGrid, arrangeGrid } from './elements/grid/layout.js';
 export * from './helpers.js';
 export type { Renderer, RenderImage, RenderText, RenderGraphics, RenderContainer } from './renderer.js';
 export { RuntimeInstance } from './runtime.js';
-export { GuiObject } from './GuiObject.js';
+export { GuiObject, type ParserCtor } from './GuiObject.js';

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -1,8 +1,8 @@
 import type { Renderer } from './renderer.js';
-import { GuiObject } from './GuiObject.js';
+import { GuiObject, type ParserCtor } from './GuiObject.js';
 
 export const RuntimeInstance = {
-  create(xml: string, renderer: Renderer) {
-    return new GuiObject(xml, renderer);
+  create(xml: string, renderer: Renderer, Parser: ParserCtor) {
+    return new GuiObject(xml, renderer, Parser);
   }
 };

--- a/packages/runtime/tests/runtime-instance.test.ts
+++ b/packages/runtime/tests/runtime-instance.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { RuntimeInstance, type GuiObject } from '../src/index.js';
 import type { Renderer, RenderGraphics, RenderContainer } from '../src/renderer.js';
+import { Parser } from '@noxigui/parser';
 import { DOMParser as XmldomParser } from '@xmldom/xmldom';
 
 class PatchedDOMParser extends XmldomParser {
@@ -58,7 +59,7 @@ const renderer: Renderer = {
 
 test('RuntimeInstance.create returns GuiObject', () => {
   const xml = '<Grid />';
-  const gui: GuiObject = RuntimeInstance.create(xml, renderer);
+  const gui: GuiObject = RuntimeInstance.create(xml, renderer, Parser);
   assert.equal(gui.container, containerObj);
   gui.layout({ width: 100, height: 100 });
   gui.setGridDebug(true);

--- a/packages/runtime/tests/template-isolation.test.ts
+++ b/packages/runtime/tests/template-isolation.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { RuntimeInstance } from '../src/index.js';
 import type { Renderer, RenderContainer } from '../src/renderer.js';
+import { Parser } from '@noxigui/parser';
 import { DOMParser as XmldomParser } from '@xmldom/xmldom';
 
 class PatchedDOMParser extends XmldomParser {
@@ -68,8 +69,8 @@ test('templates are isolated between GuiObject instances', () => {
   const xmlA = '<Grid><Resources><Template Key="T"><TextBlock Text="One"/></Template></Resources><Use Template="T"/></Grid>';
   const xmlB = '<Grid><Resources><Template Key="T"><TextBlock Text="Two"/></Template></Resources><Use Template="T"/></Grid>';
 
-  const guiA = RuntimeInstance.create(xmlA, renderer);
-  const guiB = RuntimeInstance.create(xmlB, renderer);
+  const guiA = RuntimeInstance.create(xmlA, renderer, Parser);
+  const guiB = RuntimeInstance.create(xmlB, renderer, Parser);
 
   const textA = (guiA.root as any).children[0];
   const textB = (guiB.root as any).children[0];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
 
   packages/noxi.js:
     dependencies:
+      '@noxigui/parser':
+        specifier: workspace:*
+        version: link:../parser
       '@noxigui/renderer-pixi':
         specifier: workspace:*
         version: link:../renderer-pixi
@@ -107,13 +110,13 @@ importers:
       '@noxigui/core':
         specifier: workspace:*
         version: link:../core
-      '@noxigui/parser':
-        specifier: workspace:*
-        version: link:../parser
       pixi.js:
         specifier: ^7.4.3
         version: 7.4.3
     devDependencies:
+      '@noxigui/parser':
+        specifier: workspace:*
+        version: link:../parser
       '@types/node':
         specifier: ^20.11.30
         version: 20.19.11

--- a/scripts/build-packages.js
+++ b/scripts/build-packages.js
@@ -13,7 +13,7 @@ const packages = packageDirs
     const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
     return {
       name: pkgJson.name,
-      deps: Object.assign({}, pkgJson.dependencies, pkgJson.devDependencies),
+      deps: pkgJson.dependencies || {},
     };
   })
   .filter((pkg) => pkg.name !== '@noxigui/playground');
@@ -23,14 +23,7 @@ const packageNames = new Set(packages.map((p) => p.name));
 // Build dependency graph and perform topological sort
 const graph = new Map();
 for (const pkg of packages) {
-  let deps = Object.keys(pkg.deps || {}).filter((dep) => packageNames.has(dep));
-  // runtime can import parser for optional features but doesn't require it
-  // to be built beforehand. Avoid including this edge in the build graph to
-  // prevent a circular dependency during topological sorting (parser -> runtime
-  // -> parser).
-  if (pkg.name === '@noxigui/runtime') {
-    deps = deps.filter((dep) => dep !== '@noxigui/parser');
-  }
+  const deps = Object.keys(pkg.deps || {}).filter((dep) => packageNames.has(dep));
   graph.set(pkg.name, deps);
 }
 


### PR DESCRIPTION
## Summary
- inject parser via `GuiObject` constructor and `RuntimeInstance.create`
- shift `@noxigui/parser` to dev dependency in runtime and adjust call sites
- clean build graph and scripts for new dependency direction

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b193c5f6c0832a850d1b572b612c1e