### PR TITLE
fix: expose runtime instance as default export

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -10,3 +10,5 @@ export * from './helpers.js';
 export type { Renderer, RenderImage, RenderText, RenderGraphics, RenderContainer } from './renderer.js';
 export { RuntimeInstance } from './runtime.js';
 export { GuiObject, type ParserCtor } from './GuiObject.js';
+
+export { RuntimeInstance as default } from './runtime.js';


### PR DESCRIPTION
## Summary
- expose RuntimeInstance as the default export of `@noxigui/runtime`

## Testing
- `pnpm -F @noxigui/runtime test`


------
https://chatgpt.com/codex/tasks/task_e_68b196470f24832a8498742e8602507d