### PR TITLE
fix: export runtime default

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -8,7 +8,8 @@ export { Grid, Row, Col } from './elements/Grid.js';
 export { measureGrid, arrangeGrid } from './elements/grid/layout.js';
 export * from './helpers.js';
 export type { Renderer, RenderImage, RenderText, RenderGraphics, RenderContainer } from './renderer.js';
-export { RuntimeInstance } from './runtime.js';
+import { RuntimeInstance } from './runtime.js';
+export { RuntimeInstance };
 export { GuiObject, type ParserCtor } from './GuiObject.js';
 
-export { RuntimeInstance as default } from './runtime.js';
+export default RuntimeInstance;


### PR DESCRIPTION
## Summary
- ensure runtime re-exports `RuntimeInstance` directly and as default

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b19c240648832ab64e493220a6b8c3