### PR TITLE
fix: export modules explicitly

### DIFF
--- a/packages/noxi.js/src/index.ts
+++ b/packages/noxi.js/src/index.ts
@@ -2,6 +2,8 @@ import { RuntimeInstance, type GuiObject, type Renderer } from '@noxigui/runtime
 import { createPixiRenderer } from '@noxigui/renderer-pixi';
 import { Parser } from '@noxigui/parser';
 
+export { RuntimeInstance, createPixiRenderer, Parser };
+
 const Noxi = {
   gui: {
     create(xml: string, renderer: Renderer = createPixiRenderer()): GuiObject {


### PR DESCRIPTION
## Summary
- re-export RuntimeInstance, createPixiRenderer and Parser from Noxi package to avoid star export default resolution errors

## Testing
- `pnpm test` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68b1a064b5ac832aa34154d606beba7c