### PR TITLE
fix: export modules explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
     "dev": "node scripts/build-packages.js && pnpm -F @noxigui/playground dev",
     "build": "node scripts/build-packages.js && pnpm -F @noxigui/playground build",
     "test": "node scripts/build-packages.js && pnpm -r test"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0"
   }
 }

--- a/packages/noxi.js/src/index.ts
+++ b/packages/noxi.js/src/index.ts
@@ -1,6 +1,10 @@
-import { RuntimeInstance, type GuiObject, type Renderer } from '@noxigui/runtime';
+import { RuntimeInstance } from '@noxigui/runtime';
+import type { GuiObject, Renderer } from '@noxigui/runtime';
 import { createPixiRenderer } from '@noxigui/renderer-pixi';
 import { Parser } from '@noxigui/parser';
+
+export { RuntimeInstance, createPixiRenderer, Parser };
+export type { GuiObject, Renderer };
 
 const Noxi = {
   gui: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,11 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: ^24.3.0
+        version: 24.3.0
 
   packages/core:
     devDependencies:
@@ -81,7 +85,7 @@ importers:
         version: 19.1.9(@types/react@19.1.12)
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.7.0(vite@6.3.5(@types/node@20.19.11))
+        version: 4.7.0(vite@6.3.5(@types/node@24.3.0))
       monaco-editor:
         specifier: ^0.52.2
         version: 0.52.2
@@ -90,7 +94,7 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@20.19.11)
+        version: 6.3.5(@types/node@24.3.0)
 
   packages/renderer-pixi:
     dependencies:
@@ -712,6 +716,9 @@ packages:
   '@types/node@20.19.11':
     resolution: {integrity: sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==}
 
+  '@types/node@24.3.0':
+    resolution: {integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==}
+
   '@types/react-dom@19.1.9':
     resolution: {integrity: sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==}
     peerDependencies:
@@ -961,6 +968,9 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici-types@7.10.0:
+    resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
 
   update-browserslist-db@1.1.3:
     resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
@@ -1509,6 +1519,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@24.3.0':
+    dependencies:
+      undici-types: 7.10.0
+
   '@types/react-dom@19.1.9(@types/react@19.1.12)':
     dependencies:
       '@types/react': 19.1.12
@@ -1517,7 +1531,7 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
-  '@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@20.19.11))':
+  '@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@24.3.0))':
     dependencies:
       '@babel/core': 7.28.3
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.3)
@@ -1525,7 +1539,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.5(@types/node@20.19.11)
+      vite: 6.3.5(@types/node@24.3.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -1803,6 +1817,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.10.0: {}
+
   update-browserslist-db@1.1.3(browserslist@4.25.4):
     dependencies:
       browserslist: 4.25.4
@@ -1814,7 +1830,7 @@ snapshots:
       punycode: 1.4.1
       qs: 6.14.0
 
-  vite@6.3.5(@types/node@20.19.11):
+  vite@6.3.5(@types/node@24.3.0):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
@@ -1823,7 +1839,7 @@ snapshots:
       rollup: 4.49.0
       tinyglobby: 0.2.14
     optionalDependencies:
-      '@types/node': 20.19.11
+      '@types/node': 24.3.0
       fsevents: 2.3.3
 
   yallist@3.1.1: {}


### PR DESCRIPTION
## Summary
- re-export RuntimeInstance, createPixiRenderer, Parser, and related types from Noxi package to avoid star export default resolution errors
- add `@types/node` to dev dependencies for building tests

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1a064b5ac832aa34154d606beba7c