### PR TITLE
feat: replace RuntimeInstance with Noxi

### DIFF
--- a/packages/noxi.js/src/index.ts
+++ b/packages/noxi.js/src/index.ts
@@ -1,10 +1,10 @@
-import { RuntimeInstance, type GuiObject, type Renderer } from '@noxigui/runtime';
+import { Noxi as RuntimeNoxi, type GuiObject, type Renderer } from '@noxigui/runtime';
 import { createPixiRenderer } from '@noxigui/renderer-pixi';
 
 const Noxi = {
   gui: {
     create(xml: string, renderer: Renderer = createPixiRenderer()): GuiObject {
-      return RuntimeInstance.create(xml, renderer);
+      return RuntimeNoxi.gui.create(xml, renderer);
     }
   }
 };

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import MonacoEditor from 'react-monaco-editor';
 import * as PIXI from 'pixi.js';
-import { RuntimeInstance, type RenderContainer } from '@noxigui/runtime';
+import { Noxi, type RenderContainer } from '@noxigui/runtime';
 import { createPixiRenderer } from '@noxigui/renderer-pixi';
 
 const initialSchema = `
@@ -127,7 +127,7 @@ export default function App() {
     }
 
     try {
-      const runtime = RuntimeInstance.create(code, createPixiRenderer());
+      const runtime = Noxi.gui.create(code, createPixiRenderer());
       runtimeRef.current = runtime;
       // runtime.setGridDebug(true);
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -8,5 +8,5 @@ export { Grid, Row, Col } from './elements/Grid.js';
 export { measureGrid, arrangeGrid } from './elements/grid/layout.js';
 export * from './helpers.js';
 export type { Renderer, RenderImage, RenderText, RenderGraphics, RenderContainer } from './renderer.js';
-export { RuntimeInstance } from './runtime.js';
+export { Noxi } from './runtime.js';
 export { GuiObject } from './GuiObject.js';

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -1,8 +1,10 @@
 import type { Renderer } from './renderer.js';
 import { GuiObject } from './GuiObject.js';
 
-export const RuntimeInstance = {
-  create(xml: string, renderer: Renderer) {
-    return new GuiObject(xml, renderer);
+export const Noxi = {
+  gui: {
+    create(xml: string, renderer: Renderer) {
+      return new GuiObject(xml, renderer);
+    }
   }
 };

--- a/packages/runtime/tests/noxi.test.ts
+++ b/packages/runtime/tests/noxi.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { RuntimeInstance, type GuiObject } from '../src/index.js';
+import { Noxi, type GuiObject } from '../src/index.js';
 import type { Renderer, RenderGraphics, RenderContainer } from '../src/renderer.js';
 import { DOMParser as XmldomParser } from '@xmldom/xmldom';
 
@@ -56,9 +56,9 @@ const renderer: Renderer = {
   createContainer() { return containerObj as RenderContainer; },
 };
 
-test('RuntimeInstance.create returns GuiObject', () => {
+test('Noxi.gui.create returns GuiObject', () => {
   const xml = '<Grid />';
-  const gui: GuiObject = RuntimeInstance.create(xml, renderer);
+  const gui: GuiObject = Noxi.gui.create(xml, renderer);
   assert.equal(gui.container, containerObj);
   gui.layout({ width: 100, height: 100 });
   gui.setGridDebug(true);

--- a/packages/runtime/tests/template-isolation.test.ts
+++ b/packages/runtime/tests/template-isolation.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { RuntimeInstance } from '../src/index.js';
+import { Noxi } from '../src/index.js';
 import type { Renderer, RenderContainer } from '../src/renderer.js';
 import { DOMParser as XmldomParser } from '@xmldom/xmldom';
 
@@ -68,8 +68,8 @@ test('templates are isolated between GuiObject instances', () => {
   const xmlA = '<Grid><Resources><Template Key="T"><TextBlock Text="One"/></Template></Resources><Use Template="T"/></Grid>';
   const xmlB = '<Grid><Resources><Template Key="T"><TextBlock Text="Two"/></Template></Resources><Use Template="T"/></Grid>';
 
-  const guiA = RuntimeInstance.create(xmlA, renderer);
-  const guiB = RuntimeInstance.create(xmlB, renderer);
+  const guiA = Noxi.gui.create(xmlA, renderer);
+  const guiB = Noxi.gui.create(xmlB, renderer);
 
   const textA = (guiA.root as any).children[0];
   const textB = (guiB.root as any).children[0];


### PR DESCRIPTION
## Summary
- expose `Noxi.gui.create` in runtime
- update packages to use `Noxi` instead of `RuntimeInstance`
- adjust playground and tests

## Testing
- `pnpm test`
- `pnpm -F noxi.js build`
- `pnpm -F @noxigui/playground build`


------
https://chatgpt.com/codex/tasks/task_e_68b1acfd9498832abe433f97690a5d8e