### PR TITLE
Simplify playground App to use default Noxi renderer

### DIFF
--- a/packages/noxi.js/package.json
+++ b/packages/noxi.js/package.json
@@ -1,10 +1,17 @@
 {
   "name": "noxi.js",
   "version": "0.1.0",
-  "main": "dist/index.cjs",
+  "type": "module",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
-    "build": "tsc -p tsconfig.json && mv dist/index.js dist/index.cjs"
+    "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
     "@noxigui/runtime": "workspace:*",

--- a/packages/noxi.js/tsconfig.json
+++ b/packages/noxi.js/tsconfig.json
@@ -5,9 +5,6 @@
     "declaration": true,
     "declarationMap": true,
     "allowImportingTsExtensions": false,
-    "module": "CommonJS",
-    "moduleResolution": "node",
-    "verbatimModuleSyntax": false,
     "types": ["node"]
   },
   "include": ["src"]

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -9,8 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@noxigui/runtime": "workspace:*",
-    "@noxigui/renderer-pixi": "workspace:*",
+    "noxi.js": "workspace:*",
     "pixi.js": "^7.4.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -59,7 +59,7 @@ export default function App() {
 
   const pixiRef = useRef<HTMLDivElement>(null);
   const appRef = useRef<PIXI.Application | null>(null);
-  const runtimeRef = useRef<ReturnType<typeof Noxi.gui.create> | null>(null);
+  const guiRef = useRef<ReturnType<typeof Noxi.gui.create> | null>(null);
 
   // 1) Инициализация PIXI
   useEffect(() => {
@@ -79,7 +79,7 @@ export default function App() {
         app.destroy(true, { children: true });
       } catch {}
       appRef.current = null;
-      runtimeRef.current = null;
+      guiRef.current = null;
     };
   }, []);
 
@@ -113,22 +113,22 @@ export default function App() {
     if (!app || !assetsReady) return;
 
     // убираем предыдущий рантайм
-    if (runtimeRef.current) {
-      try { runtimeRef.current.destroy(); } catch {}
+    if (guiRef.current) {
+      try { guiRef.current.destroy(); } catch {}
       app.stage.removeChildren().forEach(ch => ch.destroy());
-      runtimeRef.current = null;
+      guiRef.current = null;
     }
 
     try {
-      const runtime = Noxi.gui.create(code);
-      runtimeRef.current = runtime;
+      const gui = Noxi.gui.create(code);
+      guiRef.current = gui;
       // runtime.setGridDebug(true);
 
-      app.stage.addChild(runtime.container.getDisplayObject());
+      app.stage.addChild(gui.container.getDisplayObject());
 
       const relayout = () => {
-        if (!appRef.current || !runtimeRef.current) return;
-        runtimeRef.current.layout({
+        if (!appRef.current || !guiRef.current) return;
+        guiRef.current.layout({
           width: appRef.current.renderer.width,
           height: appRef.current.renderer.height,
         });

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -2,8 +2,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import MonacoEditor from 'react-monaco-editor';
 import * as PIXI from 'pixi.js';
-import { Noxi, type RenderContainer } from '@noxigui/runtime';
-import { createPixiRenderer } from '@noxigui/renderer-pixi';
+import Noxi from 'noxi.js';
 
 const initialSchema = `
 <Grid Margin="16" RowGap="12" ColumnGap="12">
@@ -54,19 +53,13 @@ const initialSchema = `
   </Use>
 </Grid>`;
 
-type RuntimeHandle = {
-  container: RenderContainer;
-  layout: (size: { width: number; height: number }) => void;
-  destroy: () => void;
-};
-
 export default function App() {
   const [code, setCode] = useState(initialSchema);
   const [assetsReady, setAssetsReady] = useState(false);
 
   const pixiRef = useRef<HTMLDivElement>(null);
   const appRef = useRef<PIXI.Application | null>(null);
-  const runtimeRef = useRef<RuntimeHandle | null>(null);
+  const runtimeRef = useRef<ReturnType<typeof Noxi.gui.create> | null>(null);
 
   // 1) Инициализация PIXI
   useEffect(() => {
@@ -127,7 +120,7 @@ export default function App() {
     }
 
     try {
-      const runtime = Noxi.gui.create(code, createPixiRenderer());
+      const runtime = Noxi.gui.create(code);
       runtimeRef.current = runtime;
       // runtime.setGridDebug(true);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,12 +51,9 @@ importers:
 
   packages/playground:
     dependencies:
-      '@noxigui/renderer-pixi':
+      noxi.js:
         specifier: workspace:*
-        version: link:../renderer-pixi
-      '@noxigui/runtime':
-        specifier: workspace:*
-        version: link:../runtime
+        version: link:../noxi.js
       pixi.js:
         specifier: ^7.4.3
         version: 7.4.3


### PR DESCRIPTION
## Summary
- use Noxi package in playground and rely on its default Pixi renderer
- update playground dependencies to reference `noxi.js`

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1b0945f40832abc5a220a69242189