### PR TITLE
chore: publish noxi.js build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ dist-ssr
 *.sw?
 /package-lock.json
 /pnpm-lock.yaml
+
+# Allow publishing noxi.js build output
+!packages/noxi.js/dist
+!packages/noxi.js/dist/**

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ This repository is a monorepo containing:
 
 - `@noxigui/runtime` – the core runtime implementation.
 - `@noxigui/playground` – a Vite playground for experimenting with the runtime.
+- `noxi.js` – a convenience package exporting the runtime with the default PIXI renderer.
 
 Run `pnpm dev` to start the playground or `pnpm build` to build all packages.
+Run `pnpm -F noxi.js build` to regenerate the published output in `packages/noxi.js/dist/index.js`.
 
 ```ts
 import Noxi from "noxi.js";

--- a/packages/noxi.js/dist/index.d.ts.map
+++ b/packages/noxi.js/dist/index.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":"AAAA,OAAO,EAAuB,KAAK,SAAS,EAAE,KAAK,QAAQ,EAAE,MAAM,kBAAkB,CAAC;AAGtF,QAAA,MAAM,IAAI;;oBAEM,MAAM,aAAY,QAAQ,GAA0B,SAAS;;CAI5E,CAAC;AAEF,eAAe,IAAI,CAAC"}

--- a/packages/noxi.js/dist/index.js
+++ b/packages/noxi.js/dist/index.js
@@ -1,0 +1,10 @@
+import { Noxi as RuntimeNoxi } from '@noxigui/runtime';
+import { createPixiRenderer } from '@noxigui/renderer-pixi';
+const Noxi = {
+    gui: {
+        create(xml, renderer = createPixiRenderer()) {
+            return RuntimeNoxi.gui.create(xml, renderer);
+        }
+    }
+};
+export default Noxi;


### PR DESCRIPTION
## Summary
- generate and commit the `noxi.js` build output
- document how to rebuild the published bundle and ignore rule for its dist folder

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1b69d3500832a801308a9f6abecfc