### PR TITLE
Add renderer and wrapper tests

### DIFF
--- a/packages/noxi.js/package.json
+++ b/packages/noxi.js/package.json
@@ -11,7 +11,8 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "test": "tsc -p tsconfig.json && node --test dist/tests/*.test.js"
   },
   "dependencies": {
     "@noxigui/runtime": "workspace:*",
@@ -19,6 +20,7 @@
   },
   "devDependencies": {
     "typescript": "~5.8.3",
-    "@types/node": "^20.11.30"
+    "@types/node": "^20.11.30",
+    "@xmldom/xmldom": "^0.8.11"
   }
 }

--- a/packages/noxi.js/tests/default-renderer.test.ts
+++ b/packages/noxi.js/tests/default-renderer.test.ts
@@ -1,0 +1,76 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+import path from 'node:path';
+import { Noxi as RuntimeNoxi } from '@noxigui/runtime';
+import { DOMParser as XmldomParser } from '@xmldom/xmldom';
+
+class PatchedDOMParser extends XmldomParser {
+  parseFromString(str: string, type: string) {
+    const doc = super.parseFromString(str, type);
+    const patch = (el: any) => {
+      el.children = Array.from(el.childNodes || []).filter((c: any) => c.nodeType === 1);
+      el.children.forEach(patch);
+    };
+    patch(doc.documentElement);
+    return doc;
+  }
+}
+
+(globalThis as any).DOMParser = PatchedDOMParser as any;
+
+const fakeRenderer = {
+  getTexture() { return undefined; },
+  createImage() { return {} as any; },
+  createText() {
+    return {
+      setWordWrap() {},
+      getBounds() { return { width: 0, height: 0 }; },
+      setPosition() {},
+      getDisplayObject() { return {}; },
+    } as any;
+  },
+  createGraphics() {
+    return {
+      clear() {},
+      beginFill() { return this; },
+      drawRect() { return this; },
+      endFill() {},
+      destroy() {},
+      getDisplayObject() { return {}; },
+    } as any;
+  },
+  createContainer() {
+    return {
+      addChild() {},
+      removeChild() {},
+      setPosition() {},
+      setSortableChildren() {},
+      setMask() {},
+      getDisplayObject() { return {}; },
+    } as any;
+  },
+};
+
+let called = 0;
+function createPixiRenderer() {
+  called++;
+  return fakeRenderer as any;
+}
+
+const indexPath = path.join(path.dirname(new URL(import.meta.url).pathname), '../src/index.js');
+let code = fs.readFileSync(indexPath, 'utf8')
+  .replace("import { Noxi as RuntimeNoxi } from '@noxigui/runtime';", '')
+  .replace("import { createPixiRenderer } from '@noxigui/renderer-pixi';", '')
+  .replace('export default Noxi;', '');
+code += '\nmodule.exports = { default: Noxi };';
+const module: any = { exports: {} };
+vm.runInNewContext(code, { RuntimeNoxi, createPixiRenderer, module, exports: module.exports });
+const { default: Noxi } = module.exports as { default: any };
+
+test('Noxi.gui.create uses Pixi renderer by default', () => {
+  const gui = Noxi.gui.create('<Grid/>');
+  assert.equal(called, 1);
+  gui.destroy();
+});

--- a/packages/noxi.js/tsconfig.json
+++ b/packages/noxi.js/tsconfig.json
@@ -5,7 +5,16 @@
     "declaration": true,
     "declarationMap": true,
     "allowImportingTsExtensions": false,
-    "types": ["node"]
+    "types": ["node"],
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": "src",
+    "paths": {
+      "@noxigui/runtime": ["../runtime/dist/src/index.d.ts"],
+      "@noxigui/runtime/*": ["../runtime/dist/src/*"],
+      "@noxigui/renderer-pixi": ["../renderer-pixi/dist/src/index.d.ts"],
+      "@noxigui/renderer-pixi/*": ["../renderer-pixi/dist/src/*"]
+    },
+    "moduleResolution": "node"
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }

--- a/packages/renderer-pixi/package.json
+++ b/packages/renderer-pixi/package.json
@@ -1,16 +1,25 @@
 {
   "name": "@noxigui/renderer-pixi",
   "version": "0.1.0",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "type": "module",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/src/index.js",
+      "types": "./dist/src/index.d.ts"
+    }
+  },
   "scripts": {
-    "build": "tsc -b"
+    "build": "tsc -b",
+    "test": "tsc -p tsconfig.json && node --test dist/tests/*.test.js"
   },
   "dependencies": {
     "pixi.js": "^7.4.0",
     "@noxigui/runtime": "workspace:*"
   },
   "devDependencies": {
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "@types/node": "^20.11.30"
   }
 }

--- a/packages/renderer-pixi/tests/pixi-renderer.test.ts
+++ b/packages/renderer-pixi/tests/pixi-renderer.test.ts
@@ -1,0 +1,101 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+import path from 'node:path';
+
+class FakeTexture {
+  orig: { width: number; height: number };
+  width: number;
+  height: number;
+  constructor(width = 1, height = 1) {
+    this.width = width;
+    this.height = height;
+    this.orig = { width, height };
+  }
+}
+
+class FakeSprite {
+  texture: any;
+  anchor = { set() {} };
+  scale = { set() {} };
+  x = 0;
+  y = 0;
+  constructor(tex?: any) {
+    this.texture = tex ?? fakeWhite;
+  }
+}
+
+class FakeText {
+  text: string;
+  style: any;
+  x = 0;
+  y = 0;
+  constructor(content: string, style: any) {
+    this.text = content;
+    this.style = { ...style };
+  }
+  updateText() {}
+  getLocalBounds() {
+    return { width: this.text.length * 10, height: this.style.fontSize };
+  }
+}
+
+class FakeGraphics {
+  clear() {}
+  beginFill() { return this; }
+  drawRect() { return this; }
+  endFill() {}
+  destroy() {}
+  getDisplayObject() { return {}; }
+}
+
+class FakeContainer {
+  addChild() {}
+  removeChild() {}
+  setPosition() {}
+  setSortableChildren() {}
+  setMask() {}
+  getDisplayObject() { return {}; }
+}
+
+const fakeWhite = new FakeTexture();
+const fakePixi = {
+  Sprite: FakeSprite,
+  Text: FakeText,
+  Graphics: FakeGraphics,
+  Container: FakeContainer,
+  Texture: { WHITE: fakeWhite },
+  Assets: { get: (_key: string) => undefined },
+};
+
+const indexPath = path.join(path.dirname(new URL(import.meta.url).pathname), '../src/index.js');
+let code = fs.readFileSync(indexPath, 'utf8').replace("import * as PIXI from 'pixi.js';", '');
+code = code.replace('export function createPixiRenderer()', 'function createPixiRenderer()');
+code += '\nmodule.exports = { createPixiRenderer };';
+const module: any = { exports: {} };
+vm.runInNewContext(code, { PIXI: fakePixi, module, exports: module.exports });
+const { createPixiRenderer } = module.exports as { createPixiRenderer: () => any };
+const renderer = createPixiRenderer();
+
+test('renderer creates container object', () => {
+  const c = renderer.createContainer();
+  assert.ok(c.getDisplayObject());
+});
+
+test('text wrapping updates style', () => {
+  const txt = renderer.createText('hello world', { fill: '#000', fontSize: 12 });
+  txt.setWordWrap(50, 'center');
+  assert.equal((txt as any).text.style.wordWrap, true);
+  assert.equal((txt as any).text.style.wordWrapWidth, 50);
+  assert.equal((txt as any).text.style.align, 'center');
+});
+
+test('image handling reports natural size', () => {
+  const img = renderer.createImage();
+  const tex = new FakeTexture(20, 30);
+  img.setTexture(tex);
+  const size = img.getNaturalSize();
+  assert.equal(size.width, 20);
+  assert.equal(size.height, 30);
+});

--- a/packages/renderer-pixi/tsconfig.json
+++ b/packages/renderer-pixi/tsconfig.json
@@ -2,11 +2,11 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src",
     "declaration": true,
     "declarationMap": true,
     "allowImportingTsExtensions": false,
-    "erasableSyntaxOnly": false
+    "erasableSyntaxOnly": false,
+    "types": ["node"]
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "tests/**/*"]
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -11,8 +11,9 @@
     }
   },
   "scripts": {
+    "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
     "build": "tsc -p tsconfig.json",
-    "pretest": "pnpm run build",
+    "pretest": "pnpm run clean && pnpm run build",
     "test": "if ls dist/tests/*.test.js 1> /dev/null 2>&1; then node --test dist/tests/*.test.js; else echo 'no tests'; fi"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@types/node':
         specifier: ^20.11.30
         version: 20.19.11
+      '@xmldom/xmldom':
+        specifier: ^0.8.11
+        version: 0.8.11
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -95,6 +98,9 @@ importers:
         specifier: ^7.4.0
         version: 7.4.3
     devDependencies:
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.19.11
       typescript:
         specifier: ~5.8.3
         version: 5.8.3


### PR DESCRIPTION
## Summary
- add Pixi renderer tests for container creation, text wrapping, and image sizing
- add noxi.js wrapper test ensuring default Pixi renderer usage
- configure packages to build and test with Node types

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1b6bb6828832aaa1b6f5813793bd9