### PR TITLE
feat: add StackPanel layout

### DIFF
--- a/packages/parser/src/parsers/StackPanelParser.ts
+++ b/packages/parser/src/parsers/StackPanelParser.ts
@@ -1,0 +1,32 @@
+import { StackPanel, applyGridAttachedProps, parseSizeAttrs, applyMargin } from '@noxigui/runtime';
+import type { ElementParser } from './ElementParser.js';
+import type { Parser } from '../Parser.js';
+import type { UIElement, RenderContainer } from '@noxigui/runtime';
+
+export class StackPanelParser implements ElementParser {
+  test(node: Element): boolean { return node.tagName === 'StackPanel'; }
+  parse(node: Element, p: Parser) {
+    const sp = new StackPanel();
+    const orient = node.getAttribute('Orientation');
+    if (orient === 'Horizontal' || orient === 'Vertical') sp.orientation = orient;
+    const spacingAttr = node.getAttribute('Spacing');
+    if (spacingAttr != null) sp.spacing = parseFloat(spacingAttr) || 0;
+    parseSizeAttrs(node, sp);
+    applyMargin(node, sp);
+    applyGridAttachedProps(node, sp);
+    for (const ch of Array.from(node.children)) {
+      const u = p.parseElement(ch);
+      if (u) sp.add(u);
+    }
+    return sp;
+  }
+
+  collect(into: RenderContainer, el: UIElement, collect: (into: RenderContainer, el: UIElement) => void) {
+    if (el instanceof StackPanel) {
+      for (const ch of el.children) collect(into, ch);
+      return true;
+    }
+    return false;
+  }
+}
+

--- a/packages/parser/src/parsers/index.ts
+++ b/packages/parser/src/parsers/index.ts
@@ -1,6 +1,7 @@
 export type { ElementParser } from './ElementParser.js';
 export { TextBlockParser } from './TextBlockParser.js';
 export { BorderParser } from './BorderParser.js';
+export { StackPanelParser } from './StackPanelParser.js';
 export { GridParser } from './GridParser.js';
 export { ImageParser } from './ImageParser.js';
 export { ResourcesParser } from './ResourcesParser.js';
@@ -9,6 +10,7 @@ export { UseParser } from './UseParser.js';
 
 import { TextBlockParser } from './TextBlockParser.js';
 import { BorderParser } from './BorderParser.js';
+import { StackPanelParser } from './StackPanelParser.js';
 import { GridParser } from './GridParser.js';
 import { ImageParser } from './ImageParser.js';
 import { ResourcesParser } from './ResourcesParser.js';
@@ -20,6 +22,7 @@ import type { TemplateStore } from '@noxigui/runtime';
 export const createParsers = (templates: TemplateStore): ElementParser[] => [
   new TextBlockParser(),
   new BorderParser(),
+  new StackPanelParser(),
   new GridParser(),
   new ImageParser(),
   new ResourcesParser(templates),

--- a/packages/runtime/src/elements/StackPanel.ts
+++ b/packages/runtime/src/elements/StackPanel.ts
@@ -1,0 +1,62 @@
+import { UIElement, type Size, type Rect } from '@noxigui/core';
+
+export class StackPanel extends UIElement {
+  children: UIElement[] = [];
+  orientation: 'Vertical' | 'Horizontal' = 'Vertical';
+  spacing = 0;
+
+  add(ch: UIElement) { this.children.push(ch); }
+
+  measure(avail: Size) {
+    const innerW = Math.max(0, avail.width - this.margin.l - this.margin.r);
+    const innerH = Math.max(0, avail.height - this.margin.t - this.margin.b);
+    let totalW = 0, totalH = 0, maxW = 0, maxH = 0;
+    if (this.orientation === 'Vertical') {
+      for (const ch of this.children) {
+        ch.measure({ width: innerW, height: Infinity });
+        totalH += ch.desired.height;
+        if (ch.desired.width > maxW) maxW = ch.desired.width;
+      }
+      if (this.children.length > 1) totalH += this.spacing * (this.children.length - 1);
+      const intrinsicW = maxW + this.margin.l + this.margin.r;
+      const intrinsicH = totalH + this.margin.t + this.margin.b;
+      this.desired = {
+        width: this.measureAxis('x', avail.width, intrinsicW),
+        height: this.measureAxis('y', avail.height, intrinsicH),
+      };
+    } else {
+      for (const ch of this.children) {
+        ch.measure({ width: Infinity, height: innerH });
+        totalW += ch.desired.width;
+        if (ch.desired.height > maxH) maxH = ch.desired.height;
+      }
+      if (this.children.length > 1) totalW += this.spacing * (this.children.length - 1);
+      const intrinsicW = totalW + this.margin.l + this.margin.r;
+      const intrinsicH = maxH + this.margin.t + this.margin.b;
+      this.desired = {
+        width: this.measureAxis('x', avail.width, intrinsicW),
+        height: this.measureAxis('y', avail.height, intrinsicH),
+      };
+    }
+  }
+
+  arrange(rect: Rect) {
+    const inner = this.arrangeSelf(rect);
+    if (this.orientation === 'Vertical') {
+      let y = inner.y;
+      for (const ch of this.children) {
+        const h = ch.desired.height;
+        ch.arrange({ x: inner.x, y, width: inner.width, height: h });
+        y += h + this.spacing;
+      }
+    } else {
+      let x = inner.x;
+      for (const ch of this.children) {
+        const w = ch.desired.width;
+        ch.arrange({ x, y: inner.y, width: w, height: inner.height });
+        x += w + this.spacing;
+      }
+    }
+  }
+}
+

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -2,6 +2,7 @@ export * from './template.js';
 export * from './core.js';
 export { createDefaultRegistry, RuleRegistry } from '@noxigui/core';
 export * from './elements/BorderPanel.js';
+export * from './elements/StackPanel.js';
 export * from './elements/Image.js';
 export * from './elements/Text.js';
 export { Grid, Row, Col } from './elements/Grid.js';

--- a/packages/runtime/tests/stack-panel.test.ts
+++ b/packages/runtime/tests/stack-panel.test.ts
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { StackPanel } from '../src/elements/StackPanel.js';
+import { UIElement } from '@noxigui/core';
+
+class Dummy extends UIElement {
+  constructor(public w: number, public h: number) { super(); }
+  measure() { this.desired = { width: this.w, height: this.h }; }
+  arrange(rect: any) { this.final = rect; }
+}
+
+test('measure vertical stack', () => {
+  const sp = new StackPanel();
+  sp.spacing = 5;
+  sp.add(new Dummy(50, 20));
+  sp.add(new Dummy(80, 30));
+  sp.measure({ width: 100, height: 100 });
+  assert.equal(sp.desired.width, 80);
+  assert.equal(sp.desired.height, 55);
+});
+
+test('arrange vertical stack', () => {
+  const sp = new StackPanel();
+  sp.spacing = 5;
+  const a = new Dummy(50, 20);
+  const b = new Dummy(80, 30);
+  sp.add(a); sp.add(b);
+  sp.measure({ width: 200, height: 200 });
+  sp.arrange({ x: 0, y: 0, width: 200, height: 200 });
+  assert.deepEqual(a.final, { x: 0, y: 0, width: 200, height: 20 });
+  assert.deepEqual(b.final, { x: 0, y: 25, width: 200, height: 30 });
+});
+
+test('arrange horizontal stack', () => {
+  const sp = new StackPanel();
+  sp.orientation = 'Horizontal';
+  sp.spacing = 10;
+  const a = new Dummy(10, 40);
+  const b = new Dummy(20, 50);
+  sp.add(a); sp.add(b);
+  sp.measure({ width: 100, height: 100 });
+  sp.arrange({ x: 0, y: 0, width: 100, height: 100 });
+  assert.deepEqual(a.final, { x: 0, y: 0, width: 10, height: 100 });
+  assert.deepEqual(b.final, { x: 20, y: 0, width: 20, height: 100 });
+});


### PR DESCRIPTION
## Summary
- add StackPanel container with vertical or horizontal orientation and spacing
- parse `<StackPanel>` tags and register parser
- test StackPanel measurement and arrangement

## Testing
- `pnpm -F @noxigui/runtime test`


------
https://chatgpt.com/codex/tasks/task_e_68b1fafebbd0832a9dd2e76641ac2d4f