### PR TITLE
feat: add DockPanel layout

### DIFF
--- a/packages/parser/src/parsers/DockPanelParser.ts
+++ b/packages/parser/src/parsers/DockPanelParser.ts
@@ -1,0 +1,32 @@
+import { DockPanel, applyGridAttachedProps, parseSizeAttrs, applyMargin, applyDockPanelProps } from '@noxigui/runtime';
+import type { ElementParser } from './ElementParser.js';
+import type { Parser } from '../Parser.js';
+import type { UIElement, RenderContainer } from '@noxigui/runtime';
+
+export class DockPanelParser implements ElementParser {
+  test(node: Element): boolean { return node.tagName === 'DockPanel'; }
+  parse(node: Element, p: Parser) {
+    const panel = new DockPanel();
+    const lcf = node.getAttribute('LastChildFill');
+    if (lcf && lcf.toLowerCase() === 'false') panel.lastChildFill = false;
+    parseSizeAttrs(node, panel);
+    applyMargin(node, panel);
+    applyGridAttachedProps(node, panel);
+    for (const ch of Array.from(node.children)) {
+      const u = p.parseElement(ch);
+      if (u) {
+        applyDockPanelProps(ch, u);
+        panel.add(u);
+      }
+    }
+    return panel;
+  }
+
+  collect(into: RenderContainer, el: UIElement, collect: (into: RenderContainer, el: UIElement) => void) {
+    if (el instanceof DockPanel) {
+      for (const ch of el.children) collect(into, ch);
+      return true;
+    }
+    return false;
+  }
+}

--- a/packages/parser/src/parsers/index.ts
+++ b/packages/parser/src/parsers/index.ts
@@ -2,6 +2,7 @@ export type { ElementParser } from './ElementParser.js';
 export { TextBlockParser } from './TextBlockParser.js';
 export { BorderParser } from './BorderParser.js';
 export { StackPanelParser } from './StackPanelParser.js';
+export { DockPanelParser } from './DockPanelParser.js';
 export { GridParser } from './GridParser.js';
 export { ImageParser } from './ImageParser.js';
 export { ResourcesParser } from './ResourcesParser.js';
@@ -11,6 +12,7 @@ export { UseParser } from './UseParser.js';
 import { TextBlockParser } from './TextBlockParser.js';
 import { BorderParser } from './BorderParser.js';
 import { StackPanelParser } from './StackPanelParser.js';
+import { DockPanelParser } from './DockPanelParser.js';
 import { GridParser } from './GridParser.js';
 import { ImageParser } from './ImageParser.js';
 import { ResourcesParser } from './ResourcesParser.js';
@@ -23,6 +25,7 @@ export const createParsers = (templates: TemplateStore): ElementParser[] => [
   new TextBlockParser(),
   new BorderParser(),
   new StackPanelParser(),
+  new DockPanelParser(),
   new GridParser(),
   new ImageParser(),
   new ResourcesParser(templates),

--- a/packages/runtime/src/elements/DockPanel.ts
+++ b/packages/runtime/src/elements/DockPanel.ts
@@ -1,0 +1,78 @@
+import { UIElement, type Size, type Rect } from '@noxigui/core';
+
+export type Dock = 'Left' | 'Top' | 'Right' | 'Bottom';
+const dockMap = new WeakMap<UIElement, Dock>();
+
+export class DockPanel extends UIElement {
+  children: UIElement[] = [];
+  lastChildFill = true;
+
+  add(ch: UIElement) { this.children.push(ch); }
+  static setDock(el: UIElement, d: Dock) { dockMap.set(el, d); }
+  static getDock(el: UIElement): Dock { return dockMap.get(el) || 'Left'; }
+
+  measure(avail: Size) {
+    const innerW = Math.max(0, avail.width - this.margin.l - this.margin.r);
+    const innerH = Math.max(0, avail.height - this.margin.t - this.margin.b);
+    let lrW = 0, tbH = 0, maxW = 0, maxH = 0, lastW = 0, lastH = 0;
+    const count = this.children.length;
+    for (let i = 0; i < count; i++) {
+      const ch = this.children[i];
+      const dock = DockPanel.getDock(ch);
+      const availW = Math.max(0, innerW - lrW);
+      const availH = Math.max(0, innerH - tbH);
+      ch.measure({ width: availW, height: availH });
+      const isLastFill = this.lastChildFill && i === count - 1;
+      if (isLastFill) {
+        lastW = ch.desired.width;
+        lastH = ch.desired.height;
+      } else if (dock === 'Left' || dock === 'Right') {
+        lrW += ch.desired.width;
+        if (ch.desired.height > maxH) maxH = ch.desired.height;
+      } else {
+        tbH += ch.desired.height;
+        if (ch.desired.width > maxW) maxW = ch.desired.width;
+      }
+    }
+    const intrinsicW = lrW + Math.max(maxW, lastW) + this.margin.l + this.margin.r;
+    const intrinsicH = tbH + Math.max(maxH, lastH) + this.margin.t + this.margin.b;
+    this.desired = {
+      width: this.measureAxis('x', avail.width, intrinsicW),
+      height: this.measureAxis('y', avail.height, intrinsicH),
+    };
+  }
+
+  arrange(rect: Rect) {
+    const inner = this.arrangeSelf(rect);
+    let x = inner.x, y = inner.y;
+    let w = inner.width, h = inner.height;
+    const count = this.children.length;
+    for (let i = 0; i < count; i++) {
+      const ch = this.children[i];
+      const dock = DockPanel.getDock(ch);
+      const isLastFill = this.lastChildFill && i === count - 1;
+      if (isLastFill) {
+        ch.arrange({ x, y, width: w, height: h });
+        break;
+      }
+      const cw = ch.desired.width;
+      const chh = ch.desired.height;
+      if (dock === 'Left') {
+        ch.arrange({ x, y, width: cw, height: h });
+        x += cw;
+        w = Math.max(0, w - cw);
+      } else if (dock === 'Right') {
+        ch.arrange({ x: x + w - cw, y, width: cw, height: h });
+        w = Math.max(0, w - cw);
+      } else if (dock === 'Top') {
+        ch.arrange({ x, y, width: w, height: chh });
+        y += chh;
+        h = Math.max(0, h - chh);
+      } else { // Bottom
+        ch.arrange({ x, y: y + h - chh, width: w, height: chh });
+        h = Math.max(0, h - chh);
+      }
+    }
+  }
+}
+

--- a/packages/runtime/src/helpers.ts
+++ b/packages/runtime/src/helpers.ts
@@ -1,5 +1,6 @@
 import type { UIElement } from '@noxigui/core';
 import { Grid } from './elements/Grid.js';
+import { DockPanel } from './elements/DockPanel.js';
 
 export function applyGridAttachedProps(node: Element, el: UIElement) {
   const r  = node.getAttribute('Grid.Row');         if (r)  Grid.setRow(el, +r);
@@ -8,6 +9,10 @@ export function applyGridAttachedProps(node: Element, el: UIElement) {
   const cs = node.getAttribute('Grid.ColumnSpan');  if (cs) Grid.setColSpan(el, +cs);
 }
 
+export function applyDockPanelProps(node: Element, el: UIElement) {
+  const d = node.getAttribute('DockPanel.Dock');
+  if (d === 'Left' || d === 'Top' || d === 'Right' || d === 'Bottom') DockPanel.setDock(el, d as any);
+}
 export function parseSizeAttrs(node: Element, el: UIElement) {
   const w = node.getAttribute('Width');      if (w) el.prefW = parseFloat(w);
   const h = node.getAttribute('Height');     if (h) el.prefH = parseFloat(h);

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -2,6 +2,7 @@ export * from './template.js';
 export * from './core.js';
 export { createDefaultRegistry, RuleRegistry } from '@noxigui/core';
 export * from './elements/BorderPanel.js';
+export * from './elements/DockPanel.js';
 export * from './elements/StackPanel.js';
 export * from './elements/Image.js';
 export * from './elements/Text.js';

--- a/packages/runtime/tests/dock-panel.test.ts
+++ b/packages/runtime/tests/dock-panel.test.ts
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { DockPanel } from '../src/elements/DockPanel.js';
+import { UIElement } from '@noxigui/core';
+
+class Dummy extends UIElement {
+  constructor(public w: number, public h: number) { super(); }
+  measure() { this.desired = { width: this.w, height: this.h }; }
+  arrange(rect: any) { this.final = rect; }
+}
+
+test('measure dock panel', () => {
+  const dp = new DockPanel();
+  const a = new Dummy(20, 30); DockPanel.setDock(a, 'Left');
+  const b = new Dummy(40, 10); DockPanel.setDock(b, 'Top');
+  const c = new Dummy(15, 25); DockPanel.setDock(c, 'Right');
+  const d = new Dummy(35, 5);  DockPanel.setDock(d, 'Bottom');
+  const e = new Dummy(50, 60);
+  dp.add(a); dp.add(b); dp.add(c); dp.add(d); dp.add(e);
+  dp.measure({ width: 100, height: 100 });
+  assert.equal(dp.desired.width, 85);
+  assert.equal(dp.desired.height, 75);
+});
+
+test('arrange dock panel', () => {
+  const dp = new DockPanel();
+  const a = new Dummy(20, 30); DockPanel.setDock(a, 'Left');
+  const b = new Dummy(40, 10); DockPanel.setDock(b, 'Top');
+  const c = new Dummy(15, 25); DockPanel.setDock(c, 'Right');
+  const d = new Dummy(35, 5);  DockPanel.setDock(d, 'Bottom');
+  const e = new Dummy(50, 60);
+  dp.add(a); dp.add(b); dp.add(c); dp.add(d); dp.add(e);
+  dp.measure({ width: 100, height: 100 });
+  dp.arrange({ x: 0, y: 0, width: 100, height: 100 });
+  assert.deepEqual(a.final, { x: 0, y: 0, width: 20, height: 100 });
+  assert.deepEqual(b.final, { x: 20, y: 0, width: 80, height: 10 });
+  assert.deepEqual(c.final, { x: 85, y: 10, width: 15, height: 90 });
+  assert.deepEqual(d.final, { x: 20, y: 95, width: 65, height: 5 });
+  assert.deepEqual(e.final, { x: 20, y: 10, width: 65, height: 85 });
+});
+
+test('lastChildFill false', () => {
+  const dp = new DockPanel();
+  dp.lastChildFill = false;
+  const a = new Dummy(20, 20); DockPanel.setDock(a, 'Left');
+  const b = new Dummy(30, 30); DockPanel.setDock(b, 'Top');
+  const c = new Dummy(40, 40); DockPanel.setDock(c, 'Right');
+  dp.add(a); dp.add(b); dp.add(c);
+  dp.measure({ width: 100, height: 100 });
+  dp.arrange({ x: 0, y: 0, width: 100, height: 100 });
+  assert.deepEqual(c.final, { x: 60, y: 30, width: 40, height: 70 });
+});


### PR DESCRIPTION
## Summary
- add DockPanel layout component and attachable Dock property
- support DockPanel in parser and export from runtime
- test DockPanel measurement and arrangement

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b203449654832a92f9cfd733a88d74