### PR TITLE
feat: add basic ScrollViewer control

### DIFF
--- a/packages/parser/src/parsers/ScrollViewerParser.ts
+++ b/packages/parser/src/parsers/ScrollViewerParser.ts
@@ -1,0 +1,27 @@
+import { ScrollViewer, applyGridAttachedProps, parseSizeAttrs, applyMargin } from '@noxigui/runtime';
+import type { ElementParser } from './ElementParser.js';
+import type { Parser } from '../Parser.js';
+import type { UIElement, RenderContainer } from '@noxigui/runtime';
+
+export class ScrollViewerParser implements ElementParser {
+  test(node: Element): boolean { return node.tagName === 'ScrollViewer'; }
+  parse(node: Element, p: Parser) {
+    const sv = new ScrollViewer(p.renderer);
+    parseSizeAttrs(node, sv);
+    applyMargin(node, sv);
+    applyGridAttachedProps(node, sv);
+    const first = Array.from(node.children).find(ch => ch.nodeType === Node.ELEMENT_NODE) as Element | undefined;
+    if (first) sv.child = p.parseElement(first) ?? undefined;
+    return sv;
+  }
+  collect(into: RenderContainer, el: UIElement, collect: (into: RenderContainer, el: UIElement) => void) {
+    if (el instanceof ScrollViewer) {
+      const group = el.container;
+      group.setSortableChildren(true);
+      into.addChild(group.getDisplayObject());
+      if (el.child) collect(group, el.child);
+      return true;
+    }
+    return false;
+  }
+}

--- a/packages/parser/src/parsers/ScrollViewerParser.ts
+++ b/packages/parser/src/parsers/ScrollViewerParser.ts
@@ -20,6 +20,7 @@ export class ScrollViewerParser implements ElementParser {
       group.setSortableChildren(true);
       into.addChild(group.getDisplayObject());
       if (el.child) collect(group, el.child);
+      group.addChild(el.vBar.getDisplayObject());
       return true;
     }
     return false;

--- a/packages/parser/src/parsers/index.ts
+++ b/packages/parser/src/parsers/index.ts
@@ -7,6 +7,7 @@ export { GridParser } from './GridParser.js';
 export { ImageParser } from './ImageParser.js';
 export { ResourcesParser } from './ResourcesParser.js';
 export { ContentPresenterParser } from './ContentPresenterParser.js';
+export { ScrollViewerParser } from './ScrollViewerParser.js';
 export { UseParser } from './UseParser.js';
 
 import { TextBlockParser } from './TextBlockParser.js';
@@ -17,6 +18,7 @@ import { GridParser } from './GridParser.js';
 import { ImageParser } from './ImageParser.js';
 import { ResourcesParser } from './ResourcesParser.js';
 import { ContentPresenterParser } from './ContentPresenterParser.js';
+import { ScrollViewerParser } from './ScrollViewerParser.js';
 import { UseParser } from './UseParser.js';
 import type { ElementParser } from './ElementParser.js';
 import type { TemplateStore } from '@noxigui/runtime';
@@ -30,5 +32,6 @@ export const createParsers = (templates: TemplateStore): ElementParser[] => [
   new ImageParser(),
   new ResourcesParser(templates),
   new ContentPresenterParser(),
+  new ScrollViewerParser(),
   new UseParser(templates),
 ];

--- a/packages/runtime/src/elements/ScrollViewer.ts
+++ b/packages/runtime/src/elements/ScrollViewer.ts
@@ -1,0 +1,87 @@
+import { UIElement, type Size, type Rect } from '@noxigui/core';
+import type { Renderer, RenderContainer, RenderGraphics } from '../renderer.js';
+
+export class ScrollViewer extends UIElement {
+  container: RenderContainer;
+  mask: RenderGraphics;
+  child?: UIElement;
+  horizontalOffset = 0;
+  verticalOffset = 0;
+  extentWidth = 0;
+  extentHeight = 0;
+  viewportWidth = 0;
+  viewportHeight = 0;
+
+  constructor(renderer: Renderer, child?: UIElement) {
+    super();
+    this.container = renderer.createContainer();
+    this.mask = renderer.createGraphics();
+    this.container.addChild(this.mask.getDisplayObject());
+    this.container.setMask(this.mask.getDisplayObject());
+    this.child = child;
+  }
+
+  private clampOffsets() {
+    const maxX = Math.max(0, this.extentWidth - this.viewportWidth);
+    const maxY = Math.max(0, this.extentHeight - this.viewportHeight);
+    if (this.horizontalOffset < 0) this.horizontalOffset = 0;
+    else if (this.horizontalOffset > maxX) this.horizontalOffset = maxX;
+    if (this.verticalOffset < 0) this.verticalOffset = 0;
+    else if (this.verticalOffset > maxY) this.verticalOffset = maxY;
+  }
+
+  private updateChild() {
+    if (!this.child) return;
+    this.clampOffsets();
+    this.child.arrange({
+      x: -this.horizontalOffset,
+      y: -this.verticalOffset,
+      width: this.extentWidth,
+      height: this.extentHeight,
+    });
+  }
+
+  measure(avail: Size) {
+    const innerW = Math.max(0, avail.width - this.margin.l - this.margin.r);
+    const innerH = Math.max(0, avail.height - this.margin.t - this.margin.b);
+    let cw = 0, ch = 0;
+    if (this.child) {
+      this.child.measure({ width: Infinity, height: Infinity });
+      cw = this.child.desired.width;
+      ch = this.child.desired.height;
+    }
+    this.extentWidth = cw;
+    this.extentHeight = ch;
+    const vw = Number.isFinite(innerW) ? Math.min(innerW, cw) : cw;
+    const vh = Number.isFinite(innerH) ? Math.min(innerH, ch) : ch;
+    this.viewportWidth = vw;
+    this.viewportHeight = vh;
+    const intrinsicW = vw + this.margin.l + this.margin.r;
+    const intrinsicH = vh + this.margin.t + this.margin.b;
+    this.desired = {
+      width: this.measureAxis('x', avail.width, intrinsicW),
+      height: this.measureAxis('y', avail.height, intrinsicH),
+    };
+  }
+
+  arrange(rect: Rect) {
+    const inner = this.arrangeSelf(rect);
+    this.viewportWidth = inner.width;
+    this.viewportHeight = inner.height;
+    this.container.setPosition(inner.x, inner.y);
+    this.mask.clear();
+    this.mask.beginFill(0xffffff).drawRect(0, 0, inner.width, inner.height).endFill();
+    this.updateChild();
+  }
+
+  scrollToHorizontalOffset(x: number) {
+    this.horizontalOffset = x;
+    this.updateChild();
+  }
+
+  scrollToVerticalOffset(y: number) {
+    this.verticalOffset = y;
+    this.updateChild();
+  }
+}
+

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -6,6 +6,7 @@ export * from './elements/DockPanel.js';
 export * from './elements/StackPanel.js';
 export * from './elements/Image.js';
 export * from './elements/Text.js';
+export * from './elements/ScrollViewer.js';
 export { Grid, Row, Col } from './elements/Grid.js';
 export { measureGrid, arrangeGrid } from './elements/grid/layout.js';
 export * from './helpers.js';

--- a/packages/runtime/tests/scroll-viewer.test.ts
+++ b/packages/runtime/tests/scroll-viewer.test.ts
@@ -11,14 +11,15 @@ class Dummy extends UIElement {
 }
 
 function createStubRenderer(): Renderer {
-  const graphics: RenderGraphics = {
+  const graphics = (): RenderGraphics & any => ({
     clear() {},
     beginFill() { return this; },
     drawRect() { return this; },
     endFill() {},
     destroy() {},
-    getDisplayObject() { return {}; },
-  };
+    visible: true,
+    getDisplayObject() { return this; },
+  });
   const container = () => {
     const c: RenderContainer & any = {
       mask: null,
@@ -35,7 +36,7 @@ function createStubRenderer(): Renderer {
     getTexture() { return null; },
     createImage() { throw new Error('not impl'); },
     createText() { throw new Error('not impl'); },
-    createGraphics() { return graphics; },
+    createGraphics() { return graphics(); },
     createContainer() { return container(); },
   };
 }
@@ -46,8 +47,20 @@ test('basic vertical scrolling', () => {
   const sv = new ScrollViewer(renderer, child);
   sv.measure({ width: 50, height: 50 });
   sv.arrange({ x: 0, y: 0, width: 50, height: 50 });
+  assert.ok((sv.container as any).mask, 'mask should be assigned');
+  assert.equal(sv.vBar.getDisplayObject().visible, true);
   sv.scrollToVerticalOffset(30);
   assert.equal(child.final.y, -30);
   sv.scrollToVerticalOffset(500); // clamp
   assert.equal(child.final.y, -150);
+  assert.equal(sv.vBar.getDisplayObject().visible, true);
+});
+
+test('scroll bar hidden when content fits', () => {
+  const renderer = createStubRenderer();
+  const child = new Dummy(100, 40);
+  const sv = new ScrollViewer(renderer, child);
+  sv.measure({ width: 100, height: 100 });
+  sv.arrange({ x: 0, y: 0, width: 100, height: 100 });
+  assert.equal(sv.vBar.getDisplayObject().visible, false);
 });

--- a/packages/runtime/tests/scroll-viewer.test.ts
+++ b/packages/runtime/tests/scroll-viewer.test.ts
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ScrollViewer } from '../src/elements/ScrollViewer.js';
+import { UIElement } from '@noxigui/core';
+import type { Renderer, RenderContainer, RenderGraphics } from '../src/renderer.js';
+
+class Dummy extends UIElement {
+  constructor(public w: number, public h: number) { super(); }
+  measure() { this.desired = { width: this.w, height: this.h }; }
+  arrange(rect: any) { this.final = rect; }
+}
+
+function createStubRenderer(): Renderer {
+  const graphics: RenderGraphics = {
+    clear() {},
+    beginFill() { return this; },
+    drawRect() { return this; },
+    endFill() {},
+    destroy() {},
+    getDisplayObject() { return {}; },
+  };
+  const container = () => {
+    const c: RenderContainer & any = {
+      mask: null,
+      addChild() {},
+      removeChild() {},
+      setPosition() {},
+      setSortableChildren() {},
+      setMask(m: any) { this.mask = m; },
+      getDisplayObject() { return this; },
+    };
+    return c;
+  };
+  return {
+    getTexture() { return null; },
+    createImage() { throw new Error('not impl'); },
+    createText() { throw new Error('not impl'); },
+    createGraphics() { return graphics; },
+    createContainer() { return container(); },
+  };
+}
+
+test('basic vertical scrolling', () => {
+  const renderer = createStubRenderer();
+  const child = new Dummy(100, 200);
+  const sv = new ScrollViewer(renderer, child);
+  sv.measure({ width: 50, height: 50 });
+  sv.arrange({ x: 0, y: 0, width: 50, height: 50 });
+  sv.scrollToVerticalOffset(30);
+  assert.equal(child.final.y, -30);
+  sv.scrollToVerticalOffset(500); // clamp
+  assert.equal(child.final.y, -150);
+});


### PR DESCRIPTION
## Summary
- introduce ScrollViewer element with mask-based clipping and scroll offsets
- parse `<ScrollViewer>` markup and expose new runtime export
- add basic scroll viewer test

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b20c4c882c832a8b2d20170c396952