### PR TITLE
feat: add basic scroll viewer

### DIFF
--- a/packages/core/src/elements/UIElement.ts
+++ b/packages/core/src/elements/UIElement.ts
@@ -19,10 +19,18 @@ export abstract class UIElement {
   minW = 0; minH = 0;
   prefW?: number; prefH?: number;
 
+  /** Flag set when a new arrange pass is required. */
+  arrangeDirty = false;
+
   protected registry: RuleRegistry;
 
   constructor(registry: RuleRegistry = defaultRegistry) {
     this.registry = registry;
+  }
+
+  /** Marks this element as needing an arrange pass. */
+  invalidateArrange() {
+    this.arrangeDirty = true;
   }
 
   protected measureAxis(axis: 'x' | 'y', avail: number, intrinsic: number): number {
@@ -55,6 +63,7 @@ export abstract class UIElement {
     const width = Math.max(0, rect.width - this.margin.l - this.margin.r);
     const height = Math.max(0, rect.height - this.margin.t - this.margin.b);
     this.final = { x, y, width, height };
+    this.arrangeDirty = false;
     return this.final;
   }
 

--- a/packages/parser/src/parsers/ScrollViewerParser.ts
+++ b/packages/parser/src/parsers/ScrollViewerParser.ts
@@ -1,12 +1,13 @@
 import { ScrollViewer, applyGridAttachedProps, parseSizeAttrs, applyMargin } from '@noxigui/runtime';
 import type { ElementParser } from './ElementParser.js';
 import type { Parser } from '../Parser.js';
+import type { UIElement, RenderContainer } from '@noxigui/runtime';
 
 export class ScrollViewerParser implements ElementParser {
   test(node: Element) { return node.tagName === 'ScrollViewer'; }
 
   parse(node: Element, p: Parser) {
-    const sv = new ScrollViewer();
+    const sv = new ScrollViewer(p.renderer);
 
     parseSizeAttrs(node, sv);
     applyMargin(node, sv);
@@ -31,5 +32,15 @@ export class ScrollViewerParser implements ElementParser {
     }
 
     return sv;
+  }
+
+  collect(into: RenderContainer, el: UIElement, collect: (into: RenderContainer, el: UIElement) => void) {
+    if (el instanceof ScrollViewer) {
+      const group = el.container;
+      into.addChild(group.getDisplayObject());
+      collect(group, el.presenter);
+      return true;
+    }
+    return false;
   }
 }

--- a/packages/parser/src/parsers/ScrollViewerParser.ts
+++ b/packages/parser/src/parsers/ScrollViewerParser.ts
@@ -1,0 +1,35 @@
+import { ScrollViewer, applyGridAttachedProps, parseSizeAttrs, applyMargin } from '@noxigui/runtime';
+import type { ElementParser } from './ElementParser.js';
+import type { Parser } from '../Parser.js';
+
+export class ScrollViewerParser implements ElementParser {
+  test(node: Element) { return node.tagName === 'ScrollViewer'; }
+
+  parse(node: Element, p: Parser) {
+    const sv = new ScrollViewer();
+
+    parseSizeAttrs(node, sv);
+    applyMargin(node, sv);
+    applyGridAttachedProps(node, sv);
+
+    const hsv = node.getAttribute('HorizontalScrollBarVisibility');
+    if (hsv) sv.horizontalScrollBarVisibility = hsv as any;
+
+    const vsv = node.getAttribute('VerticalScrollBarVisibility');
+    if (vsv) sv.verticalScrollBarVisibility = vsv as any;
+
+    const ccs = node.getAttribute('CanContentScroll');
+    if (ccs) sv.canContentScroll = ccs === 'True';
+
+    const zoomMode = node.getAttribute('ZoomMode');
+    if (zoomMode) (sv as any).zoomMode = zoomMode as any;
+
+    const childEl = Array.from(node.children)[0] as Element | undefined;
+    if (childEl) {
+      const parsed = p.parseElement(childEl);
+      if (parsed) sv.setContent(parsed);
+    }
+
+    return sv;
+  }
+}

--- a/packages/parser/src/parsers/index.ts
+++ b/packages/parser/src/parsers/index.ts
@@ -8,6 +8,7 @@ export { ImageParser } from './ImageParser.js';
 export { ResourcesParser } from './ResourcesParser.js';
 export { ContentPresenterParser } from './ContentPresenterParser.js';
 export { UseParser } from './UseParser.js';
+export { ScrollViewerParser } from './ScrollViewerParser.js';
 
 import { TextBlockParser } from './TextBlockParser.js';
 import { BorderParser } from './BorderParser.js';
@@ -18,6 +19,7 @@ import { ImageParser } from './ImageParser.js';
 import { ResourcesParser } from './ResourcesParser.js';
 import { ContentPresenterParser } from './ContentPresenterParser.js';
 import { UseParser } from './UseParser.js';
+import { ScrollViewerParser } from './ScrollViewerParser.js';
 import type { ElementParser } from './ElementParser.js';
 import type { TemplateStore } from '@noxigui/runtime';
 
@@ -30,5 +32,6 @@ export const createParsers = (templates: TemplateStore): ElementParser[] => [
   new ImageParser(),
   new ResourcesParser(templates),
   new ContentPresenterParser(),
+  new ScrollViewerParser(),
   new UseParser(templates),
 ];

--- a/packages/parser/tests/basic.test.ts
+++ b/packages/parser/tests/basic.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { Parser } from '../src/Parser.js';
-import { Grid, Text, TemplateStore } from '@noxigui/runtime';
+import { Grid, Text, TemplateStore, ScrollViewer } from '@noxigui/runtime';
 import { DOMParser as XmldomParser } from '@xmldom/xmldom';
 
 class PatchedDOMParser extends XmldomParser {
@@ -65,4 +65,14 @@ test('parse simple grid with text', () => {
   const child = grid.children[0];
   assert.ok(child instanceof Text);
   assert.ok(container.getDisplayObject().children.length >= 1);
+});
+
+test('parse scrollviewer with child', () => {
+  const renderer = createRenderer();
+  const parser = new Parser(renderer, new TemplateStore(), new PatchedDOMParser());
+  const { root } = parser.parse('<ScrollViewer CanContentScroll="True"><TextBlock Text="Hello"/></ScrollViewer>');
+  assert.ok(root instanceof ScrollViewer);
+  const sv = root as ScrollViewer;
+  assert.equal(sv.canContentScroll, true);
+  assert.ok(sv.content instanceof Text);
 });

--- a/packages/runtime/src/elements/ScrollViewer.ts
+++ b/packages/runtime/src/elements/ScrollViewer.ts
@@ -1,0 +1,137 @@
+import { UIElement, type Size, type Rect } from '@noxigui/core';
+import { ContentPresenter } from '../core.js';
+
+export type ScrollBarVisibility = 'Disabled'|'Hidden'|'Auto'|'Visible';
+export interface ScrollChangedArgs {
+  horizontalOffset: number;
+  verticalOffset: number;
+  extentWidth: number;
+  extentHeight: number;
+  viewportWidth: number;
+  viewportHeight: number;
+}
+
+export class ScrollViewer extends UIElement {
+  // sizes
+  extentWidth = 0; extentHeight = 0;
+  viewportWidth = 0; viewportHeight = 0;
+  scrollableWidth = 0; scrollableHeight = 0;
+
+  // offsets
+  private _hx = 0; private _vy = 0;
+  get horizontalOffset() { return this._hx; }
+  get verticalOffset() { return this._vy; }
+
+  // flags
+  canContentScroll = false;
+  horizontalScrollBarVisibility: ScrollBarVisibility = 'Auto';
+  verticalScrollBarVisibility: ScrollBarVisibility = 'Auto';
+
+  // content
+  private presenter = new ContentPresenter();
+
+  // events
+  readonly scrollChanged = new Set<(e: ScrollChangedArgs) => void>();
+  private lastArgs: ScrollChangedArgs = {
+    horizontalOffset: -1,
+    verticalOffset: -1,
+    extentWidth: -1,
+    extentHeight: -1,
+    viewportWidth: -1,
+    viewportHeight: -1,
+  };
+
+  setContent(ch: UIElement) { this.presenter.child = ch; }
+  get content() { return this.presenter.child; }
+
+  private clampOffsets() {
+    if (this._hx < 0) this._hx = 0;
+    if (this._vy < 0) this._vy = 0;
+    if (this._hx > this.scrollableWidth) this._hx = this.scrollableWidth;
+    if (this._vy > this.scrollableHeight) this._vy = this.scrollableHeight;
+  }
+
+  measure(avail: Size) {
+    const innerW = Math.max(0, avail.width - this.margin.l - this.margin.r);
+    const innerH = Math.max(0, avail.height - this.margin.t - this.margin.b);
+
+    const ch = this.presenter.child;
+    if (ch) {
+      ch.measure({ width: Infinity, height: Infinity });
+      this.extentWidth = ch.desired.width;
+      this.extentHeight = ch.desired.height;
+    } else {
+      this.extentWidth = this.extentHeight = 0;
+    }
+
+    this.viewportWidth = Math.min(innerW, this.extentWidth);
+    this.viewportHeight = Math.min(innerH, this.extentHeight);
+    this.scrollableWidth = Math.max(0, this.extentWidth - this.viewportWidth);
+    this.scrollableHeight = Math.max(0, this.extentHeight - this.viewportHeight);
+
+    const intrinsicW = this.viewportWidth + this.margin.l + this.margin.r;
+    const intrinsicH = this.viewportHeight + this.margin.t + this.margin.b;
+    this.desired = {
+      width: this.measureAxis('x', avail.width, intrinsicW),
+      height: this.measureAxis('y', avail.height, intrinsicH),
+    };
+  }
+
+  arrange(rect: Rect) {
+    const inner = this.arrangeSelf(rect);
+    this.viewportWidth = inner.width;
+    this.viewportHeight = inner.height;
+    this.scrollableWidth = Math.max(0, this.extentWidth - this.viewportWidth);
+    this.scrollableHeight = Math.max(0, this.extentHeight - this.viewportHeight);
+    this.clampOffsets();
+    this.presenter.arrange({
+      x: inner.x - this._hx,
+      y: inner.y - this._vy,
+      width: this.extentWidth,
+      height: this.extentHeight,
+    });
+
+    const args: ScrollChangedArgs = {
+      horizontalOffset: this._hx,
+      verticalOffset: this._vy,
+      extentWidth: this.extentWidth,
+      extentHeight: this.extentHeight,
+      viewportWidth: this.viewportWidth,
+      viewportHeight: this.viewportHeight,
+    };
+    const last = this.lastArgs;
+    const changed =
+      args.horizontalOffset !== last.horizontalOffset ||
+      args.verticalOffset !== last.verticalOffset ||
+      args.extentWidth !== last.extentWidth ||
+      args.extentHeight !== last.extentHeight ||
+      args.viewportWidth !== last.viewportWidth ||
+      args.viewportHeight !== last.viewportHeight;
+    if (changed) {
+      this.lastArgs = { ...args };
+      for (const fn of this.scrollChanged) fn(args);
+    }
+  }
+
+  // scrolling APIs
+  ScrollToHorizontalOffset(v: number) { this._hx = v; this.clampOffsets(); }
+  ScrollToVerticalOffset(v: number) { this._vy = v; this.clampOffsets(); }
+  LineUp() { this.ScrollToVerticalOffset(this._vy - 16); }
+  LineDown() { this.ScrollToVerticalOffset(this._vy + 16); }
+  LineLeft() { this.ScrollToHorizontalOffset(this._hx - 16); }
+  LineRight() { this.ScrollToHorizontalOffset(this._hx + 16); }
+  PageUp() { this.ScrollToVerticalOffset(this._vy - this.viewportHeight); }
+  PageDown() { this.ScrollToVerticalOffset(this._vy + this.viewportHeight); }
+  PageLeft() { this.ScrollToHorizontalOffset(this._hx - this.viewportWidth); }
+  PageRight() { this.ScrollToHorizontalOffset(this._hx + this.viewportWidth); }
+  MouseWheelUp() { this.ScrollToVerticalOffset(this._vy - 48); }
+  MouseWheelDown() { this.ScrollToVerticalOffset(this._vy + 48); }
+
+  ChangeView(h?: number|null, v?: number|null, _zoom?: number|null, _disableAnimation = false): boolean {
+    if (h != null) this._hx = h;
+    if (v != null) this._vy = v;
+    this.clampOffsets();
+    return true;
+  }
+}
+

--- a/packages/runtime/src/elements/ScrollViewer.ts
+++ b/packages/runtime/src/elements/ScrollViewer.ts
@@ -1,5 +1,6 @@
 import { UIElement, type Size, type Rect } from '@noxigui/core';
 import { ContentPresenter } from '../core.js';
+import type { Renderer, RenderContainer, RenderGraphics } from '../renderer.js';
 
 export type ScrollBarVisibility = 'Disabled'|'Hidden'|'Auto'|'Visible';
 export interface ScrollChangedArgs {
@@ -9,6 +10,18 @@ export interface ScrollChangedArgs {
   extentHeight: number;
   viewportWidth: number;
   viewportHeight: number;
+}
+
+export interface IScrollInfo {
+  canHorizontallyScroll: boolean;
+  canVerticallyScroll: boolean;
+  extentWidth: number; extentHeight: number;
+  viewportWidth: number; viewportHeight: number;
+  horizontalOffset: number; verticalOffset: number;
+  lineUp(): void; lineDown(): void; lineLeft(): void; lineRight(): void;
+  pageUp(): void; pageDown(): void; pageLeft(): void; pageRight(): void;
+  setHorizontalOffset(x: number): void;
+  setVerticalOffset(y: number): void;
 }
 
 export class ScrollViewer extends UIElement {
@@ -26,9 +39,16 @@ export class ScrollViewer extends UIElement {
   canContentScroll = false;
   horizontalScrollBarVisibility: ScrollBarVisibility = 'Auto';
   verticalScrollBarVisibility: ScrollBarVisibility = 'Auto';
+  computedHorizontalScrollBarVisibility: 'Disabled'|'Hidden'|'Visible' = 'Hidden';
+  computedVerticalScrollBarVisibility: 'Disabled'|'Hidden'|'Visible' = 'Hidden';
+  panningMode: 'None'|'Both'|'HorizontalOnly'|'VerticalOnly' = 'None';
 
-  // content
-  private presenter = new ContentPresenter();
+  // content & visuals
+  presenter = new ContentPresenter();
+  container: RenderContainer;
+  private maskG: RenderGraphics | null = null;
+  private renderer: Renderer;
+  private scrollInfo?: IScrollInfo;
 
   // events
   readonly scrollChanged = new Set<(e: ScrollChangedArgs) => void>();
@@ -41,14 +61,38 @@ export class ScrollViewer extends UIElement {
     viewportHeight: -1,
   };
 
-  setContent(ch: UIElement) { this.presenter.child = ch; }
+  constructor(renderer: Renderer) {
+    super();
+    this.renderer = renderer;
+    this.container = renderer.createContainer();
+  }
+
+  setContent(ch: UIElement) {
+    this.presenter.child = ch;
+    const maybe = ch as any as Partial<IScrollInfo>;
+    this.scrollInfo = this.canContentScroll && typeof maybe.setHorizontalOffset === 'function'
+      ? (ch as any as IScrollInfo)
+      : undefined;
+  }
   get content() { return this.presenter.child; }
 
   private clampOffsets() {
-    if (this._hx < 0) this._hx = 0;
-    if (this._vy < 0) this._vy = 0;
-    if (this._hx > this.scrollableWidth) this._hx = this.scrollableWidth;
-    if (this._vy > this.scrollableHeight) this._vy = this.scrollableHeight;
+    if (this.scrollInfo) {
+      const si = this.scrollInfo;
+      if (si.horizontalOffset < 0) si.setHorizontalOffset(0);
+      if (si.verticalOffset < 0) si.setVerticalOffset(0);
+      const maxH = Math.max(0, si.extentWidth - si.viewportWidth);
+      const maxV = Math.max(0, si.extentHeight - si.viewportHeight);
+      if (si.horizontalOffset > maxH) si.setHorizontalOffset(maxH);
+      if (si.verticalOffset > maxV) si.setVerticalOffset(maxV);
+      this._hx = si.horizontalOffset;
+      this._vy = si.verticalOffset;
+    } else {
+      if (this._hx < 0) this._hx = 0;
+      if (this._vy < 0) this._vy = 0;
+      if (this._hx > this.scrollableWidth) this._hx = this.scrollableWidth;
+      if (this._vy > this.scrollableHeight) this._vy = this.scrollableHeight;
+    }
   }
 
   measure(avail: Size) {
@@ -58,14 +102,46 @@ export class ScrollViewer extends UIElement {
     const ch = this.presenter.child;
     if (ch) {
       ch.measure({ width: Infinity, height: Infinity });
-      this.extentWidth = ch.desired.width;
-      this.extentHeight = ch.desired.height;
+      if (this.scrollInfo) {
+        const si = this.scrollInfo;
+        this.extentWidth = si.extentWidth;
+        this.extentHeight = si.extentHeight;
+        this.viewportWidth = Math.min(innerW, si.viewportWidth);
+        this.viewportHeight = Math.min(innerH, si.viewportHeight);
+      } else {
+        this.extentWidth = ch.desired.width;
+        this.extentHeight = ch.desired.height;
+        this.viewportWidth = Math.min(innerW, this.extentWidth);
+        this.viewportHeight = Math.min(innerH, this.extentHeight);
+      }
     } else {
       this.extentWidth = this.extentHeight = 0;
+      this.viewportWidth = Math.min(innerW, 0);
+      this.viewportHeight = Math.min(innerH, 0);
     }
 
-    this.viewportWidth = Math.min(innerW, this.extentWidth);
-    this.viewportHeight = Math.min(innerH, this.extentHeight);
+    // scrollbar visibility resolution (two-pass, thickness currently 0)
+    const resolve = (mode: ScrollBarVisibility, need: boolean): 'Disabled'|'Hidden'|'Visible' => {
+      if (mode === 'Auto') return need ? 'Visible' : 'Hidden';
+      if (mode === 'Disabled') return 'Disabled';
+      return mode;
+    };
+
+    let needH = this.extentWidth > this.viewportWidth;
+    let needV = this.extentHeight > this.viewportHeight;
+    this.computedHorizontalScrollBarVisibility = resolve(this.horizontalScrollBarVisibility, needH);
+    this.computedVerticalScrollBarVisibility = resolve(this.verticalScrollBarVisibility, needV);
+
+    // second pass assuming bars may take space (bar size 0 for now)
+    const hBar = this.computedHorizontalScrollBarVisibility === 'Visible' ? 0 : 0;
+    const vBar = this.computedVerticalScrollBarVisibility === 'Visible' ? 0 : 0;
+    this.viewportWidth = Math.min(innerW - vBar, this.extentWidth);
+    this.viewportHeight = Math.min(innerH - hBar, this.extentHeight);
+    needH = this.extentWidth > this.viewportWidth;
+    needV = this.extentHeight > this.viewportHeight;
+    this.computedHorizontalScrollBarVisibility = resolve(this.horizontalScrollBarVisibility, needH);
+    this.computedVerticalScrollBarVisibility = resolve(this.verticalScrollBarVisibility, needV);
+
     this.scrollableWidth = Math.max(0, this.extentWidth - this.viewportWidth);
     this.scrollableHeight = Math.max(0, this.extentHeight - this.viewportHeight);
 
@@ -79,14 +155,29 @@ export class ScrollViewer extends UIElement {
 
   arrange(rect: Rect) {
     const inner = this.arrangeSelf(rect);
-    this.viewportWidth = inner.width;
-    this.viewportHeight = inner.height;
+    if (this.scrollInfo) {
+      this.viewportWidth = this.scrollInfo.viewportWidth;
+      this.viewportHeight = this.scrollInfo.viewportHeight;
+    } else {
+      this.viewportWidth = inner.width;
+      this.viewportHeight = inner.height;
+    }
     this.scrollableWidth = Math.max(0, this.extentWidth - this.viewportWidth);
     this.scrollableHeight = Math.max(0, this.extentHeight - this.viewportHeight);
     this.clampOffsets();
+
+    this.container.setPosition(inner.x, inner.y);
+    if (!this.maskG) {
+      this.maskG = this.renderer.createGraphics();
+      this.container.addChild(this.maskG.getDisplayObject());
+      this.container.setMask(this.maskG.getDisplayObject());
+    }
+    this.maskG.clear();
+    this.maskG.beginFill(0xffffff).drawRect(0, 0, this.viewportWidth, this.viewportHeight).endFill();
+
     this.presenter.arrange({
-      x: inner.x - this._hx,
-      y: inner.y - this._vy,
+      x: -this._hx,
+      y: -this._vy,
       width: this.extentWidth,
       height: this.extentHeight,
     });
@@ -114,23 +205,93 @@ export class ScrollViewer extends UIElement {
   }
 
   // scrolling APIs
-  ScrollToHorizontalOffset(v: number) { this._hx = v; this.clampOffsets(); }
-  ScrollToVerticalOffset(v: number) { this._vy = v; this.clampOffsets(); }
-  LineUp() { this.ScrollToVerticalOffset(this._vy - 16); }
-  LineDown() { this.ScrollToVerticalOffset(this._vy + 16); }
-  LineLeft() { this.ScrollToHorizontalOffset(this._hx - 16); }
-  LineRight() { this.ScrollToHorizontalOffset(this._hx + 16); }
-  PageUp() { this.ScrollToVerticalOffset(this._vy - this.viewportHeight); }
-  PageDown() { this.ScrollToVerticalOffset(this._vy + this.viewportHeight); }
-  PageLeft() { this.ScrollToHorizontalOffset(this._hx - this.viewportWidth); }
-  PageRight() { this.ScrollToHorizontalOffset(this._hx + this.viewportWidth); }
+  ScrollToHorizontalOffset(v: number) {
+    if (this.scrollInfo) this.scrollInfo.setHorizontalOffset(v);
+    else this._hx = v;
+    this.clampOffsets();
+    this.invalidateArrange();
+  }
+  ScrollToVerticalOffset(v: number) {
+    if (this.scrollInfo) this.scrollInfo.setVerticalOffset(v);
+    else this._vy = v;
+    this.clampOffsets();
+    this.invalidateArrange();
+  }
+  LineUp() {
+    if (this.scrollInfo) this.scrollInfo.lineUp();
+    else this.ScrollToVerticalOffset(this._vy - 16);
+    this.invalidateArrange();
+  }
+  LineDown() {
+    if (this.scrollInfo) this.scrollInfo.lineDown();
+    else this.ScrollToVerticalOffset(this._vy + 16);
+    this.invalidateArrange();
+  }
+  LineLeft() {
+    if (this.scrollInfo) this.scrollInfo.lineLeft();
+    else this.ScrollToHorizontalOffset(this._hx - 16);
+    this.invalidateArrange();
+  }
+  LineRight() {
+    if (this.scrollInfo) this.scrollInfo.lineRight();
+    else this.ScrollToHorizontalOffset(this._hx + 16);
+    this.invalidateArrange();
+  }
+  PageUp() {
+    if (this.scrollInfo) this.scrollInfo.pageUp();
+    else this.ScrollToVerticalOffset(this._vy - this.viewportHeight);
+    this.invalidateArrange();
+  }
+  PageDown() {
+    if (this.scrollInfo) this.scrollInfo.pageDown();
+    else this.ScrollToVerticalOffset(this._vy + this.viewportHeight);
+    this.invalidateArrange();
+  }
+  PageLeft() {
+    if (this.scrollInfo) this.scrollInfo.pageLeft();
+    else this.ScrollToHorizontalOffset(this._hx - this.viewportWidth);
+    this.invalidateArrange();
+  }
+  PageRight() {
+    if (this.scrollInfo) this.scrollInfo.pageRight();
+    else this.ScrollToHorizontalOffset(this._hx + this.viewportWidth);
+    this.invalidateArrange();
+  }
   MouseWheelUp() { this.ScrollToVerticalOffset(this._vy - 48); }
   MouseWheelDown() { this.ScrollToVerticalOffset(this._vy + 48); }
 
+  onWheel(evt: { deltaX?: number; deltaY: number; shiftKey?: boolean }) {
+    const dy = evt.deltaY;
+    if (evt.shiftKey) {
+      this.ScrollToHorizontalOffset(this._hx + dy);
+    } else {
+      this.ScrollToVerticalOffset(this._vy + dy);
+    }
+  }
+  onKeyDown(key: string) {
+    switch (key) {
+      case 'ArrowUp': this.LineUp(); break;
+      case 'ArrowDown': this.LineDown(); break;
+      case 'ArrowLeft': this.LineLeft(); break;
+      case 'ArrowRight': this.LineRight(); break;
+      case 'PageUp': this.PageUp(); break;
+      case 'PageDown': this.PageDown(); break;
+      case 'Home': this.ScrollToVerticalOffset(0); break;
+      case 'End': this.ScrollToVerticalOffset(this.scrollableHeight); break;
+    }
+  }
+
   ChangeView(h?: number|null, v?: number|null, _zoom?: number|null, _disableAnimation = false): boolean {
-    if (h != null) this._hx = h;
-    if (v != null) this._vy = v;
+    if (h != null) {
+      if (this.scrollInfo) this.scrollInfo.setHorizontalOffset(h);
+      else this._hx = h;
+    }
+    if (v != null) {
+      if (this.scrollInfo) this.scrollInfo.setVerticalOffset(v);
+      else this._vy = v;
+    }
     this.clampOffsets();
+    this.invalidateArrange();
     return true;
   }
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -12,3 +12,4 @@ export * from './helpers.js';
 export type { Renderer, RenderImage, RenderText, RenderGraphics, RenderContainer } from './renderer.js';
 export { Noxi } from './runtime.js';
 export { GuiObject } from './GuiObject.js';
+export * from './elements/ScrollViewer.js';

--- a/packages/runtime/tests/scroll-viewer.test.ts
+++ b/packages/runtime/tests/scroll-viewer.test.ts
@@ -1,7 +1,42 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { ScrollViewer } from '../src/elements/ScrollViewer.js';
+import { ScrollViewer, type IScrollInfo } from '../src/elements/ScrollViewer.js';
 import { UIElement } from '@noxigui/core';
+import type { Renderer } from '../src/renderer.js';
+
+const createRenderer = (): Renderer => ({
+  getTexture() { return undefined as any; },
+  createImage() { return {} as any; },
+  createText() {
+    return {
+      setWordWrap() {},
+      getBounds() { return { width: 0, height: 0 }; },
+      setPosition() {},
+      getDisplayObject() { return {}; },
+    } as any;
+  },
+  createGraphics() {
+    return {
+      clear() {},
+      beginFill() { return this; },
+      drawRect() { return this; },
+      endFill() {},
+      destroy() {},
+      getDisplayObject() { return {}; },
+    } as any;
+  },
+  createContainer() {
+    const obj = { children: [] as any[] };
+    return {
+      addChild(child: any) { obj.children.push(child); },
+      removeChild(child: any) { const i = obj.children.indexOf(child); if (i >= 0) obj.children.splice(i,1); },
+      setPosition() {},
+      setSortableChildren() {},
+      setMask() {},
+      getDisplayObject() { return obj; },
+    } as any;
+  },
+});
 
 class Dummy extends UIElement {
   constructor(public w: number, public h: number) { super(); }
@@ -10,7 +45,7 @@ class Dummy extends UIElement {
 }
 
 test('measure computes extent and viewport', () => {
-  const sv = new ScrollViewer();
+  const sv = new ScrollViewer(createRenderer());
   sv.setContent(new Dummy(200, 400));
   sv.measure({ width: 100, height: 150 });
   assert.equal(sv.extentWidth, 200);
@@ -22,7 +57,7 @@ test('measure computes extent and viewport', () => {
 });
 
 test('scroll offsets clamp to scrollable range', () => {
-  const sv = new ScrollViewer();
+  const sv = new ScrollViewer(createRenderer());
   const ch = new Dummy(200, 400);
   sv.setContent(ch);
   sv.measure({ width: 100, height: 100 });
@@ -37,4 +72,56 @@ test('scroll offsets clamp to scrollable range', () => {
   sv.arrange({ x: 0, y: 0, width: 100, height: 100 });
   assert.equal(sv.verticalOffset, sv.scrollableHeight);
   assert.equal(ch.final.y, -sv.scrollableHeight);
+});
+
+test('ScrollTo invalidates arrange', () => {
+  const sv = new ScrollViewer(createRenderer());
+  sv.setContent(new Dummy(100, 200));
+  sv.measure({ width: 100, height: 100 });
+  sv.arrange({ x: 0, y: 0, width: 100, height: 100 });
+  sv.ScrollToVerticalOffset(10);
+  assert.equal(sv.arrangeDirty, true);
+});
+
+test('computed scrollbar visibility', () => {
+  const sv = new ScrollViewer(createRenderer());
+  sv.setContent(new Dummy(50, 200));
+  sv.measure({ width: 100, height: 100 });
+  assert.equal(sv.computedVerticalScrollBarVisibility, 'Visible');
+  assert.equal(sv.computedHorizontalScrollBarVisibility, 'Hidden');
+});
+
+class DummySI extends UIElement implements IScrollInfo {
+  canHorizontallyScroll = false;
+  canVerticallyScroll = true;
+  extentWidth = 1; extentHeight = 10;
+  viewportWidth = 1; viewportHeight = 4;
+  horizontalOffset = 0; verticalOffset = 0;
+  measure() { this.desired = { width: 0, height: 0 }; }
+  arrange(rect: any) { this.final = rect; }
+  lineUp() { this.verticalOffset = Math.max(0, this.verticalOffset - 1); }
+  lineDown() { this.verticalOffset = Math.min(this.extentHeight - this.viewportHeight, this.verticalOffset + 1); }
+  lineLeft() {}
+  lineRight() {}
+  pageUp() { this.verticalOffset = Math.max(0, this.verticalOffset - this.viewportHeight); }
+  pageDown() { this.verticalOffset = Math.min(this.extentHeight - this.viewportHeight, this.verticalOffset + this.viewportHeight); }
+  pageLeft() {}
+  pageRight() {}
+  setHorizontalOffset(x: number) { this.horizontalOffset = x; }
+  setVerticalOffset(y: number) { this.verticalOffset = y; }
+}
+
+test('CanContentScroll with IScrollInfo child', () => {
+  const sv = new ScrollViewer(createRenderer());
+  sv.canContentScroll = true;
+  const si = new DummySI();
+  sv.setContent(si);
+  sv.measure({ width: 100, height: 100 });
+  sv.arrange({ x: 0, y: 0, width: 100, height: 100 });
+  assert.equal(sv.extentHeight, 10);
+  assert.equal(sv.viewportHeight, 4);
+  sv.LineDown();
+  sv.arrange({ x: 0, y: 0, width: 100, height: 100 });
+  assert.equal(sv.verticalOffset, 1);
+  assert.equal(si.verticalOffset, 1);
 });

--- a/packages/runtime/tests/scroll-viewer.test.ts
+++ b/packages/runtime/tests/scroll-viewer.test.ts
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ScrollViewer } from '../src/elements/ScrollViewer.js';
+import { UIElement } from '@noxigui/core';
+
+class Dummy extends UIElement {
+  constructor(public w: number, public h: number) { super(); }
+  measure() { this.desired = { width: this.w, height: this.h }; }
+  arrange(rect: any) { this.final = rect; }
+}
+
+test('measure computes extent and viewport', () => {
+  const sv = new ScrollViewer();
+  sv.setContent(new Dummy(200, 400));
+  sv.measure({ width: 100, height: 150 });
+  assert.equal(sv.extentWidth, 200);
+  assert.equal(sv.extentHeight, 400);
+  assert.equal(sv.viewportWidth, 100);
+  assert.equal(sv.viewportHeight, 150);
+  assert.equal(sv.scrollableWidth, 100);
+  assert.equal(sv.scrollableHeight, 250);
+});
+
+test('scroll offsets clamp to scrollable range', () => {
+  const sv = new ScrollViewer();
+  const ch = new Dummy(200, 400);
+  sv.setContent(ch);
+  sv.measure({ width: 100, height: 100 });
+  sv.arrange({ x: 0, y: 0, width: 100, height: 100 });
+
+  sv.ScrollToVerticalOffset(50);
+  sv.arrange({ x: 0, y: 0, width: 100, height: 100 });
+  assert.equal(sv.verticalOffset, 50);
+  assert.equal(ch.final.y, -50);
+
+  sv.ScrollToVerticalOffset(1000);
+  sv.arrange({ x: 0, y: 0, width: 100, height: 100 });
+  assert.equal(sv.verticalOffset, sv.scrollableHeight);
+  assert.equal(ch.final.y, -sv.scrollableHeight);
+});


### PR DESCRIPTION
## Summary
- introduce `ScrollViewer` UI element with offset properties, extent and viewport calculations
- support `<ScrollViewer>` in parser for basic attributes and single child content
- add unit tests validating scrolling measurement and offset clamping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b213a276e4832ab71573e89c88f18e