### PR TITLE
Handle wheel events automatically in ScrollViewer

### DIFF
--- a/packages/parser/src/parsers/ScrollViewerParser.ts
+++ b/packages/parser/src/parsers/ScrollViewerParser.ts
@@ -4,11 +4,11 @@ import type { Parser } from '../Parser.js';
 import type { UIElement, RenderContainer } from '@noxigui/runtime';
 
 export class ScrollViewerParser implements ElementParser {
-  test(node: Element) { return node.tagName === 'ScrollViewer'; }
+  test(node: Element) {console.log("Test ScrollViewer"); return node.tagName === 'ScrollViewer'; }
 
   parse(node: Element, p: Parser) {
     const sv = new ScrollViewer(p.renderer);
-
+    console.log("ScrollViewer is created")
     parseSizeAttrs(node, sv);
     applyMargin(node, sv);
     applyGridAttachedProps(node, sv);

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -68,7 +68,10 @@ export default function App() {
     const app = new PIXI.Application({
       resizeTo: pixiRef.current,
       backgroundColor: 0x222222,
-      antialias: true
+      antialias: true,
+      eventFeatures: {
+        wheel: true
+      }
     });
 
     pixiRef.current.appendChild(app.view as HTMLCanvasElement);

--- a/packages/renderer-pixi/src/index.ts
+++ b/packages/renderer-pixi/src/index.ts
@@ -113,8 +113,9 @@ class PixiRenderContainer implements RenderContainer {
     this.c.mask = mask;
   }
   addEventListener(type: string, handler: (evt: any) => void) {
+    console.log(`Listener ${type} is added to container`);
     // PIXI containers act as event emitters
-    (this.c as any).on?.(type, handler);
+    (this.c as any).addListener(type, handler);
   }
   getDisplayObject() {
     return this.c;

--- a/packages/renderer-pixi/src/index.ts
+++ b/packages/renderer-pixi/src/index.ts
@@ -94,6 +94,8 @@ class PixiRenderContainer implements RenderContainer {
   c: PIXI.Container;
   constructor() {
     this.c = new PIXI.Container();
+    // enable event dispatch so wheel listeners can be attached
+    (this.c as any).eventMode = 'static';
   }
   addChild(child: any) {
     this.c.addChild(child);
@@ -109,6 +111,10 @@ class PixiRenderContainer implements RenderContainer {
   }
   setMask(mask: any | null) {
     this.c.mask = mask;
+  }
+  addEventListener(type: string, handler: (evt: any) => void) {
+    // PIXI containers act as event emitters
+    (this.c as any).on?.(type, handler);
   }
   getDisplayObject() {
     return this.c;

--- a/packages/runtime/src/elements/ScrollViewer.ts
+++ b/packages/runtime/src/elements/ScrollViewer.ts
@@ -65,6 +65,8 @@ export class ScrollViewer extends UIElement {
     super();
     this.renderer = renderer;
     this.container = renderer.createContainer();
+    // auto-handle wheel scrolling if renderer supports event listeners
+    this.container.addEventListener?.('wheel', (evt: any) => this.onWheel(evt));
   }
 
   setContent(ch: UIElement) {

--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -29,7 +29,7 @@ export interface RenderContainer {
   setSortableChildren(value: boolean): void;
   setMask(mask: any | null): void;
   /** Optional event hookup used by interactive elements */
-  addEventListener?(type: string, handler: (evt: any) => void): void;
+  addEventListener(type: string, handler: (evt: any) => void): void;
   getDisplayObject(): any;
 }
 

--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -28,6 +28,8 @@ export interface RenderContainer {
   setPosition(x: number, y: number): void;
   setSortableChildren(value: boolean): void;
   setMask(mask: any | null): void;
+  /** Optional event hookup used by interactive elements */
+  addEventListener?(type: string, handler: (evt: any) => void): void;
   getDisplayObject(): any;
 }
 

--- a/packages/runtime/tests/scroll-viewer.test.ts
+++ b/packages/runtime/tests/scroll-viewer.test.ts
@@ -26,13 +26,14 @@ const createRenderer = (): Renderer => ({
     } as any;
   },
   createContainer() {
-    const obj = { children: [] as any[] };
+    const obj = { children: [] as any[], handlers: {} as Record<string, (e: any) => void> };
     return {
       addChild(child: any) { obj.children.push(child); },
       removeChild(child: any) { const i = obj.children.indexOf(child); if (i >= 0) obj.children.splice(i,1); },
       setPosition() {},
       setSortableChildren() {},
       setMask() {},
+       addEventListener(type: string, cb: (e: any) => void) { obj.handlers[type] = cb; },
       getDisplayObject() { return obj; },
     } as any;
   },
@@ -124,4 +125,16 @@ test('CanContentScroll with IScrollInfo child', () => {
   sv.arrange({ x: 0, y: 0, width: 100, height: 100 });
   assert.equal(sv.verticalOffset, 1);
   assert.equal(si.verticalOffset, 1);
+});
+
+test('wheel events scroll automatically', () => {
+  const sv = new ScrollViewer(createRenderer());
+  sv.setContent(new Dummy(100, 300));
+  sv.measure({ width: 100, height: 100 });
+  sv.arrange({ x: 0, y: 0, width: 100, height: 100 });
+  const obj: any = sv.container.getDisplayObject();
+  obj.handlers['wheel']({ deltaY: 20 });
+  // apply arrange pass after event
+  sv.arrange({ x: 0, y: 0, width: 100, height: 100 });
+  assert.equal(sv.verticalOffset, 20);
 });


### PR DESCRIPTION
## Summary
- auto-scroll when wheel events occur in ScrollViewer
- expose optional `addEventListener` on render containers and implement for Pixi
- test wheel events trigger scrolling

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b294015164832a81a900f8ffdc60ab