### PR TITLE
feat(studio): add project type schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "scripts": {
     "dev": "node scripts/build-packages.js && pnpm -F @noxigui/playground dev",
+    "studio": "node scripts/build-packages.js && pnpm -F @noxigui/studio dev",
     "build": "node scripts/build-packages.js && pnpm -F @noxigui/playground build",
     "test": "node scripts/build-packages.js && pnpm -r test"
   }

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -14,7 +14,9 @@
     "react-dom": "^19.1.0",
     "react-monaco-editor": "^0.58.0",
     "zod": "^4.1.5",
-    "zustand": "^5.0.8"
+    "zustand": "^5.0.8",
+    "pixi.js": "^7.4.0",
+    "noxi.js": "workspace:*"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.12",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -9,8 +9,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "monaco-editor": "^0.52.2",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-monaco-editor": "^0.58.0",
+    "zod": "^4.1.5",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@types/react": "^19.1.6",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -17,9 +17,13 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.12",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.5.1",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.12",
     "typescript": "~5.8.3",
     "vite": "^6.3.5"
   }

--- a/packages/studio/postcss.config.cjs
+++ b/packages/studio/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
+};

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -3,6 +3,7 @@ import { useStudio } from "./state/useStudio";
 import { CodeTab } from "./tabs/CodeTab";
 import { DataTab } from "./tabs/DataTab";
 import { AssetsTab } from "./tabs/AssetsTab";
+import { Renderer } from "./Renderer";
 
 export default function App() {
   const { project, activeTab, setTab, exportProject, loadProject, newProject } = useStudio();
@@ -72,8 +73,7 @@ export default function App() {
             {activeTab === "Assets" && <AssetsTab />}
           </div>
           <div className="overflow-hidden">
-            {/* Pixi renderer panel placeholder */}
-            <div id="renderer-root" className="w-full h-full" />
+            <Renderer />
           </div>
         </div>
       </div>

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -49,12 +49,7 @@ export default function App() {
 
       {/* Main area */}
       <div className="flex-1 grid grid-rows-[auto_1fr]">
-        <div className="h-10 border-b border-neutral-800 flex items-center px-3 justify-between">
-          <div className="flex gap-3">
-            <TabButton label="Code" active={activeTab === "Code"} onClick={() => setTab("Code")} />
-            <TabButton label="Data" active={activeTab === "Data"} onClick={() => setTab("Data")} />
-            <TabButton label="Assets" active={activeTab === "Assets"} onClick={() => setTab("Assets")} />
-          </div>
+        <div className="h-10 border-b border-neutral-800 flex items-center px-3 justify-end">
           <div className="flex items-center gap-2">
             <div className="text-sm opacity-80">{project.name}</div>
             <button
@@ -80,15 +75,3 @@ export default function App() {
     </div>
   );
 }
-
-function TabButton({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
-  return (
-    <button
-      className={`px-3 py-1 rounded ${active ? "bg-neutral-800" : "hover:bg-neutral-900"}`}
-      onClick={onClick}
-    >
-      {label}
-    </button>
-  );
-}
-

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -1,10 +1,94 @@
-import React from 'react';
+import React from "react";
+import { useStudio } from "./state/useStudio";
+import { CodeTab } from "./tabs/CodeTab";
+import { DataTab } from "./tabs/DataTab";
+import { AssetsTab } from "./tabs/AssetsTab";
 
 export default function App() {
+  const { project, activeTab, setTab, exportProject, loadProject, newProject } = useStudio();
+
+  const onImport = async () => {
+    const inp = document.createElement("input");
+    inp.type = "file";
+    const file: File = await new Promise((res) => {
+      inp.onchange = () => res(inp.files![0]);
+      inp.click();
+    });
+    const json = JSON.parse(await file.text());
+    loadProject(json);
+  };
+
+  const onExport = () => {
+    const blob = new Blob([exportProject()], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "project.noxiproject";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const onRun = () => {
+    console.log("run");
+  };
+
   return (
-    <div>
-      <h1>Studio</h1>
-      <p>Welcome to Noxigui Studio</p>
+    <div className="w-screen h-screen flex bg-neutral-950 text-neutral-200">
+      {/* Left Toolbar */}
+      <div className="w-14 border-r border-neutral-800 flex flex-col gap-2 p-2">
+        <button onClick={() => setTab("Code")} title="Code">{"</>"}</button>
+        <button onClick={() => setTab("Data")} title="Data">{"{ }"}</button>
+        <button onClick={() => setTab("Assets")} title="Assets">🖼️</button>
+        <button onClick={onRun} title="Run">▶️</button>
+        <div className="mt-auto flex flex-col gap-2">
+          <button onClick={onImport} title="Import">📥</button>
+          <button onClick={onExport} title="Export">📤</button>
+        </div>
+      </div>
+
+      {/* Main area */}
+      <div className="flex-1 grid grid-rows-[auto_1fr]">
+        <div className="h-10 border-b border-neutral-800 flex items-center px-3 justify-between">
+          <div className="flex gap-3">
+            <TabButton label="Code" active={activeTab === "Code"} onClick={() => setTab("Code")} />
+            <TabButton label="Data" active={activeTab === "Data"} onClick={() => setTab("Data")} />
+            <TabButton label="Assets" active={activeTab === "Assets"} onClick={() => setTab("Assets")} />
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="text-sm opacity-80">{project.name}</div>
+            <button
+              className="px-2 py-1 rounded bg-neutral-800 hover:bg-neutral-700 text-sm"
+              onClick={newProject}
+            >
+              New
+            </button>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2">
+          <div className="border-r border-neutral-800 overflow-hidden">
+            {activeTab === "Code" && <CodeTab />}
+            {activeTab === "Data" && <DataTab />}
+            {activeTab === "Assets" && <AssetsTab />}
+          </div>
+          <div className="overflow-hidden">
+            {/* Pixi renderer panel placeholder */}
+            <div id="renderer-root" className="w-full h-full" />
+          </div>
+        </div>
+      </div>
     </div>
   );
 }
+
+function TabButton({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      className={`px-3 py-1 rounded ${active ? "bg-neutral-800" : "hover:bg-neutral-900"}`}
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+}
+

--- a/packages/studio/src/Renderer.tsx
+++ b/packages/studio/src/Renderer.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useRef } from "react";
+import * as PIXI from "pixi.js";
+import Noxi from "noxi.js";
+import { useStudio } from "./state/useStudio";
+import type { Project } from "./types/project";
+
+export function Renderer() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const appRef = useRef<PIXI.Application | null>(null);
+  const guiRef = useRef<ReturnType<typeof Noxi.gui.create> | null>(null);
+  const resizeCleanup = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const app = new PIXI.Application({
+      resizeTo: container,
+      backgroundColor: 0x222222,
+      antialias: true,
+      eventFeatures: { wheel: true },
+    });
+    container.appendChild(app.view as HTMLCanvasElement);
+    appRef.current = app;
+
+    const reload = async (project: Project) => {
+      if (!appRef.current) return;
+      const app = appRef.current;
+
+      if (guiRef.current) {
+        try {
+          guiRef.current.destroy();
+        } catch {}
+        app.stage.removeChildren().forEach((ch) => ch.destroy());
+        guiRef.current = null;
+      }
+      resizeCleanup.current?.();
+      resizeCleanup.current = null;
+
+      try {
+        PIXI.Assets.reset();
+        if (project.assets?.length) {
+          PIXI.Assets.add(project.assets.map((a) => ({ alias: a.alias, src: a.src })));
+          await PIXI.Assets.load(project.assets.map((a) => a.alias));
+        }
+
+        const gui = Noxi.gui.create(project.layout);
+        guiRef.current = gui;
+        (gui as any).viewModel = project.data;
+        app.stage.addChild(gui.container.getDisplayObject());
+
+        const relayout = () => {
+          if (!appRef.current || !guiRef.current) return;
+          guiRef.current.layout({
+            width: appRef.current.renderer.width,
+            height: appRef.current.renderer.height,
+          });
+        };
+        relayout();
+
+        const r: any = app.renderer as any;
+        if (r && typeof r.on === "function") r.on("resize", relayout);
+        else if (r && typeof r.addListener === "function") r.addListener("resize", relayout);
+        resizeCleanup.current = () => {
+          if (r && typeof r.off === "function") r.off("resize", relayout);
+          else if (r && typeof r.removeListener === "function") r.removeListener("resize", relayout);
+        };
+      } catch (e) {
+        console.warn("Runtime reload error:", e);
+      }
+    };
+
+    const unsub = useStudio.subscribe((state, prev) => {
+      if (state.project !== prev.project) reload(state.project);
+    });
+    reload(useStudio.getState().project);
+
+    return () => {
+      unsub();
+      resizeCleanup.current?.();
+      if (guiRef.current) {
+        try {
+          guiRef.current.destroy();
+        } catch {}
+        guiRef.current = null;
+      }
+      if (appRef.current) {
+        try {
+          (appRef.current as any).destroy(true, { children: true });
+        } catch {}
+        appRef.current = null;
+      }
+    };
+  }, []);
+
+  return <div id="renderer-root" ref={containerRef} className="w-full h-full" />;
+}

--- a/packages/studio/src/state/useStudio.ts
+++ b/packages/studio/src/state/useStudio.ts
@@ -2,6 +2,14 @@ import { create } from "zustand";
 import { ProjectZ } from "../types/project";
 import type { Project } from "../types/project";
 
+export const defaultProject: Project = {
+  name: "Untitled",
+  version: "0.1",
+  layout: "<Grid/>",
+  data: {},
+  assets: [],
+};
+
 type Tab = "Code" | "Data" | "Assets";
 type Dirty = { layout: boolean; data: boolean; assets: boolean };
 type StudioState = {
@@ -14,9 +22,10 @@ type StudioState = {
   setLayout: (s: string) => void;
   setData: (o: any) => void;
   setAssets: (a: Project["assets"]) => void;
+  newProject: () => void;
 };
 export const useStudio = create<StudioState>((set, get) => ({
-  project: { name: "Untitled", version: "0.1", layout: "<Grid/>", data: {}, assets: [] },
+  project: { ...defaultProject },
   activeTab: "Code",
   dirty: { layout: false, data: false, assets: false },
   setTab: (t) => set({ activeTab: t }),
@@ -35,4 +44,6 @@ export const useStudio = create<StudioState>((set, get) => ({
     set((s) => ({ project: { ...s.project, data }, dirty: { ...s.dirty, data: true } })),
   setAssets: (assets) =>
     set((s) => ({ project: { ...s.project, assets }, dirty: { ...s.dirty, assets: true } })),
+  newProject: () =>
+    set({ project: { ...defaultProject }, dirty: { layout: false, data: false, assets: false } }),
 }));

--- a/packages/studio/src/state/useStudio.ts
+++ b/packages/studio/src/state/useStudio.ts
@@ -24,26 +24,68 @@ type StudioState = {
   setAssets: (a: Project["assets"]) => void;
   newProject: () => void;
 };
-export const useStudio = create<StudioState>((set, get) => ({
-  project: { ...defaultProject },
-  activeTab: "Code",
-  dirty: { layout: false, data: false, assets: false },
-  setTab: (t) => set({ activeTab: t }),
-  loadProject: (raw) => {
-    const parsed = ProjectZ.parse(raw);
-    set({ project: parsed, dirty: { layout: false, data: false, assets: false } });
-  },
-  exportProject: () => {
-    const out = JSON.stringify(get().project, null, 2);
-    set({ dirty: { layout: false, data: false, assets: false } });
-    return out;
-  },
-  setLayout: (layout) =>
-    set((s) => ({ project: { ...s.project, layout }, dirty: { ...s.dirty, layout: true } })),
-  setData: (data) =>
-    set((s) => ({ project: { ...s.project, data }, dirty: { ...s.dirty, data: true } })),
-  setAssets: (assets) =>
-    set((s) => ({ project: { ...s.project, assets }, dirty: { ...s.dirty, assets: true } })),
-  newProject: () =>
-    set({ project: { ...defaultProject }, dirty: { layout: false, data: false, assets: false } }),
-}));
+export const useStudio = create<StudioState>((set, get) => {
+  const STORAGE_KEY = "noxigui:project";
+  let saveTimer: ReturnType<typeof setTimeout>;
+
+  const scheduleSave = () => {
+    if (typeof window === "undefined" || !window.localStorage) return;
+    clearTimeout(saveTimer);
+    saveTimer = setTimeout(() => {
+      try {
+        window.localStorage.setItem(
+          STORAGE_KEY,
+          JSON.stringify(get().project)
+        );
+      } catch {
+        /* ignore */
+      }
+    }, 500);
+  };
+
+  let initial: Project = { ...defaultProject };
+  if (typeof window !== "undefined" && window.localStorage) {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      try {
+        initial = ProjectZ.parse(JSON.parse(raw));
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  return {
+    project: initial,
+    activeTab: "Code",
+    dirty: { layout: false, data: false, assets: false },
+    setTab: (t) => set({ activeTab: t }),
+    loadProject: (raw) => {
+      const parsed = ProjectZ.parse(raw);
+      set({ project: parsed, dirty: { layout: false, data: false, assets: false } });
+      scheduleSave();
+    },
+    exportProject: () => {
+      const out = JSON.stringify(get().project, null, 2);
+      set({ dirty: { layout: false, data: false, assets: false } });
+      scheduleSave();
+      return out;
+    },
+    setLayout: (layout) => {
+      set((s) => ({ project: { ...s.project, layout }, dirty: { ...s.dirty, layout: true } }));
+      scheduleSave();
+    },
+    setData: (data) => {
+      set((s) => ({ project: { ...s.project, data }, dirty: { ...s.dirty, data: true } }));
+      scheduleSave();
+    },
+    setAssets: (assets) => {
+      set((s) => ({ project: { ...s.project, assets }, dirty: { ...s.dirty, assets: true } }));
+      scheduleSave();
+    },
+    newProject: () => {
+      set({ project: { ...defaultProject }, dirty: { layout: false, data: false, assets: false } });
+      scheduleSave();
+    },
+  };
+});

--- a/packages/studio/src/state/useStudio.ts
+++ b/packages/studio/src/state/useStudio.ts
@@ -1,0 +1,38 @@
+import { create } from "zustand";
+import { ProjectZ } from "../types/project";
+import type { Project } from "../types/project";
+
+type Tab = "Code" | "Data" | "Assets";
+type Dirty = { layout: boolean; data: boolean; assets: boolean };
+type StudioState = {
+  project: Project;
+  activeTab: Tab;
+  dirty: Dirty;
+  setTab: (t: Tab) => void;
+  loadProject: (raw: unknown) => void;
+  exportProject: () => string;
+  setLayout: (s: string) => void;
+  setData: (o: any) => void;
+  setAssets: (a: Project["assets"]) => void;
+};
+export const useStudio = create<StudioState>((set, get) => ({
+  project: { name: "Untitled", version: "0.1", layout: "<Grid/>", data: {}, assets: [] },
+  activeTab: "Code",
+  dirty: { layout: false, data: false, assets: false },
+  setTab: (t) => set({ activeTab: t }),
+  loadProject: (raw) => {
+    const parsed = ProjectZ.parse(raw);
+    set({ project: parsed, dirty: { layout: false, data: false, assets: false } });
+  },
+  exportProject: () => {
+    const out = JSON.stringify(get().project, null, 2);
+    set({ dirty: { layout: false, data: false, assets: false } });
+    return out;
+  },
+  setLayout: (layout) =>
+    set((s) => ({ project: { ...s.project, layout }, dirty: { ...s.dirty, layout: true } })),
+  setData: (data) =>
+    set((s) => ({ project: { ...s.project, data }, dirty: { ...s.dirty, data: true } })),
+  setAssets: (assets) =>
+    set((s) => ({ project: { ...s.project, assets }, dirty: { ...s.dirty, assets: true } })),
+}));

--- a/packages/studio/src/style.css
+++ b/packages/studio/src/style.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;

--- a/packages/studio/src/tabs/AssetsTab.tsx
+++ b/packages/studio/src/tabs/AssetsTab.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useStudio } from "../state/useStudio";
 import type { DragEvent } from "react";
 

--- a/packages/studio/src/tabs/AssetsTab.tsx
+++ b/packages/studio/src/tabs/AssetsTab.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+
+export function AssetsTab() {
+  return <div className="p-2">Assets</div>;
+}
+

--- a/packages/studio/src/tabs/AssetsTab.tsx
+++ b/packages/studio/src/tabs/AssetsTab.tsx
@@ -1,6 +1,41 @@
-import React from "react";
+import { useStudio } from "../state/useStudio";
+import type { DragEvent } from "react";
 
 export function AssetsTab() {
-  return <div className="p-2">Assets</div>;
+  const { project, setAssets } = useStudio();
+
+  const onDrop = async (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const files = Array.from(e.dataTransfer.files);
+    const entries = await Promise.all(
+      files.map(async (f) => {
+        const url = URL.createObjectURL(f);
+        return { alias: f.name.replace(/\.[^/.]+$/, ""), src: url };
+      })
+    );
+    setAssets([...(project.assets || []), ...entries]);
+  };
+
+  return (
+    <div
+      className="h-full w-full p-3"
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={onDrop}
+    >
+      <div className="grid grid-cols-4 gap-8">
+        {(project.assets || []).map((a) => (
+          <div key={a.alias} className="flex flex-col gap-2 items-center">
+            <img
+              src={a.src}
+              className="w-24 h-24 object-contain bg-neutral-900 rounded"
+            />
+            <div className="text-xs opacity-80">{a.alias}</div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-4 text-sm opacity-60">Drag & drop images here…</div>
+    </div>
+  );
 }
+
 

--- a/packages/studio/src/tabs/CodeTab.tsx
+++ b/packages/studio/src/tabs/CodeTab.tsx
@@ -1,6 +1,17 @@
-import React from "react";
+import MonacoEditor from "react-monaco-editor";
+import { useStudio } from "../state/useStudio";
 
 export function CodeTab() {
-  return <div className="p-2">Code</div>;
+  const { project, setLayout } = useStudio();
+  return (
+    <MonacoEditor
+      language="xml"
+      value={project.layout}
+      onChange={(v) => setLayout(v)}
+      options={{ minimap: { enabled: false }, fontSize: 14 }}
+      width="100%"
+      height="100%"
+    />
+  );
 }
 

--- a/packages/studio/src/tabs/CodeTab.tsx
+++ b/packages/studio/src/tabs/CodeTab.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import MonacoEditor from "react-monaco-editor";
 import { useStudio } from "../state/useStudio";
 

--- a/packages/studio/src/tabs/CodeTab.tsx
+++ b/packages/studio/src/tabs/CodeTab.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+
+export function CodeTab() {
+  return <div className="p-2">Code</div>;
+}
+

--- a/packages/studio/src/tabs/DataTab.tsx
+++ b/packages/studio/src/tabs/DataTab.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import MonacoEditor from "react-monaco-editor";
 import { useStudio } from "../state/useStudio";
 

--- a/packages/studio/src/tabs/DataTab.tsx
+++ b/packages/studio/src/tabs/DataTab.tsx
@@ -1,6 +1,21 @@
-import React from "react";
+import MonacoEditor from "react-monaco-editor";
+import { useStudio } from "../state/useStudio";
 
 export function DataTab() {
-  return <div className="p-2">Data</div>;
+  const { project, setData } = useStudio();
+  return (
+    <MonacoEditor
+      language="json"
+      value={JSON.stringify(project.data, null, 2)}
+      onChange={(v) => {
+        try {
+          setData(JSON.parse(v));
+        } catch {}
+      }}
+      options={{ minimap: { enabled: false }, fontSize: 14 }}
+      width="100%"
+      height="100%"
+    />
+  );
 }
 

--- a/packages/studio/src/tabs/DataTab.tsx
+++ b/packages/studio/src/tabs/DataTab.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+
+export function DataTab() {
+  return <div className="p-2">Data</div>;
+}
+

--- a/packages/studio/src/types/project.ts
+++ b/packages/studio/src/types/project.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const AssetZ = z.object({ alias: z.string(), src: z.string() });
+export const ProjectZ = z.object({
+  name: z.string(),
+  version: z.string().default("0.1"),
+  layout: z.string(),
+  data: z.record(z.string(), z.any()).default({}),
+  assets: z.array(AssetZ).default([]),
+  meta: z.object({ theme: z.string().optional() }).optional()
+});
+export type Project = z.infer<typeof ProjectZ>;
+

--- a/packages/studio/tailwind.config.cjs
+++ b/packages/studio/tailwind.config.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    "./index.html",
+    "./src/**/*.{ts,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,7 +75,7 @@ importers:
         version: 19.1.9(@types/react@19.1.12)
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.7.0(vite@6.3.5(@types/node@20.19.11))
+        version: 4.7.0(vite@6.3.5(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1))
       monaco-editor:
         specifier: ^0.52.2
         version: 0.52.2
@@ -84,7 +84,7 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@20.19.11)
+        version: 6.3.5(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)
 
   packages/renderer-pixi:
     dependencies:
@@ -142,6 +142,9 @@ importers:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@19.1.12)(react@19.1.1)
     devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4.1.12
+        version: 4.1.12
       '@types/react':
         specifier: ^19.1.6
         version: 19.1.12
@@ -150,15 +153,28 @@ importers:
         version: 19.1.9(@types/react@19.1.12)
       '@vitejs/plugin-react':
         specifier: ^4.5.1
-        version: 4.7.0(vite@6.3.5(@types/node@20.19.11))
+        version: 4.7.0(vite@6.3.5(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1))
+      autoprefixer:
+        specifier: ^10.4.21
+        version: 10.4.21(postcss@8.5.6)
+      postcss:
+        specifier: ^8.5.6
+        version: 8.5.6
+      tailwindcss:
+        specifier: ^4.1.12
+        version: 4.1.12
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@20.19.11)
+        version: 6.3.5(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)
 
 packages:
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -403,8 +419,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -719,6 +742,94 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tailwindcss/node@4.1.12':
+    resolution: {integrity: sha512-3hm9brwvQkZFe++SBt+oLjo4OLDtkvlE8q2WalaD/7QWaeM7KEJbAiY/LJZUaCs7Xa8aUu4xy3uoyX4q54UVdQ==}
+
+  '@tailwindcss/oxide-android-arm64@4.1.12':
+    resolution: {integrity: sha512-oNY5pq+1gc4T6QVTsZKwZaGpBb2N1H1fsc1GD4o7yinFySqIuRZ2E4NvGasWc6PhYJwGK2+5YT1f9Tp80zUQZQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.12':
+    resolution: {integrity: sha512-cq1qmq2HEtDV9HvZlTtrj671mCdGB93bVY6J29mwCyaMYCP/JaUBXxrQQQm7Qn33AXXASPUb2HFZlWiiHWFytw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.1.12':
+    resolution: {integrity: sha512-6UCsIeFUcBfpangqlXay9Ffty9XhFH1QuUFn0WV83W8lGdX8cD5/+2ONLluALJD5+yJ7k8mVtwy3zMZmzEfbLg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.12':
+    resolution: {integrity: sha512-JOH/f7j6+nYXIrHobRYCtoArJdMJh5zy5lr0FV0Qu47MID/vqJAY3r/OElPzx1C/wdT1uS7cPq+xdYYelny1ww==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.12':
+    resolution: {integrity: sha512-v4Ghvi9AU1SYgGr3/j38PD8PEe6bRfTnNSUE3YCMIRrrNigCFtHZ2TCm8142X8fcSqHBZBceDx+JlFJEfNg5zQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.12':
+    resolution: {integrity: sha512-YP5s1LmetL9UsvVAKusHSyPlzSRqYyRB0f+Kl/xcYQSPLEw/BvGfxzbH+ihUciePDjiXwHh+p+qbSP3SlJw+6g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.12':
+    resolution: {integrity: sha512-V8pAM3s8gsrXcCv6kCHSuwyb/gPsd863iT+v1PGXC4fSL/OJqsKhfK//v8P+w9ThKIoqNbEnsZqNy+WDnwQqCA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.12':
+    resolution: {integrity: sha512-xYfqYLjvm2UQ3TZggTGrwxjYaLB62b1Wiysw/YE3Yqbh86sOMoTn0feF98PonP7LtjsWOWcXEbGqDL7zv0uW8Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.12':
+    resolution: {integrity: sha512-ha0pHPamN+fWZY7GCzz5rKunlv9L5R8kdh+YNvP5awe3LtuXb5nRi/H27GeL2U+TdhDOptU7T6Is7mdwh5Ar3A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.1.12':
+    resolution: {integrity: sha512-4tSyu3dW+ktzdEpuk6g49KdEangu3eCYoqPhWNsZgUhyegEda3M9rG0/j1GV/JjVVsj+lG7jWAyrTlLzd/WEBg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.12':
+    resolution: {integrity: sha512-iGLyD/cVP724+FGtMWslhcFyg4xyYyM+5F4hGvKA7eifPkXHRAUDFaimu53fpNg9X8dfP75pXx/zFt/jlNF+lg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.12':
+    resolution: {integrity: sha512-NKIh5rzw6CpEodv/++r0hGLlfgT/gFN+5WNdZtvh6wpU2BpGNgdjvj6H2oFc8nCM839QM1YOhjpgbAONUb4IxA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.1.12':
+    resolution: {integrity: sha512-gM5EoKHW/ukmlEtphNwaGx45fGoEmP10v51t9unv55voWh6WrOL19hfuIdo2FjxIaZzw776/BUQg7Pck++cIVw==}
+    engines: {node: '>= 10'}
+
+  '@tailwindcss/postcss@4.1.12':
+    resolution: {integrity: sha512-5PpLYhCAwf9SJEeIsSmCDLgyVfdBhdBpzX1OJ87anT9IVR0Z9pjM0FNixCAUAHGnMBGB8K99SwAheXrT0Kh6QQ==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -761,6 +872,13 @@ packages:
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
 
+  autoprefixer@10.4.21:
+    resolution: {integrity: sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
   browserslist@4.25.4:
     resolution: {integrity: sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -777,6 +895,10 @@ packages:
   caniuse-lite@1.0.30001737:
     resolution: {integrity: sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==}
 
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -792,6 +914,10 @@ packages:
       supports-color:
         optional: true
 
+  detect-libc@2.0.4:
+    resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
+    engines: {node: '>=8'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -801,6 +927,10 @@ packages:
 
   electron-to-chromium@1.5.211:
     resolution: {integrity: sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==}
+
+  enhanced-resolve@5.18.3:
+    resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
+    engines: {node: '>=10.13.0'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -835,6 +965,9 @@ packages:
       picomatch:
         optional: true
 
+  fraction.js@4.3.7:
+    resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -859,6 +992,9 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -869,6 +1005,10 @@ packages:
 
   ismobilejs@1.1.1:
     resolution: {integrity: sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==}
+
+  jiti@2.5.1:
+    resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
+    hasBin: true
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -883,12 +1023,92 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  lightningcss-darwin-arm64@1.30.1:
+    resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.30.1:
+    resolution: {integrity: sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.30.1:
+    resolution: {integrity: sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.30.1:
+    resolution: {integrity: sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.30.1:
+    resolution: {integrity: sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.30.1:
+    resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.30.1:
+    resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.30.1:
+    resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.30.1:
+    resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.30.1:
+    resolution: {integrity: sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.30.1:
+    resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
+    engines: {node: '>= 12.0.0'}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.18:
+    resolution: {integrity: sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.0.2:
+    resolution: {integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==}
+    engines: {node: '>= 18'}
+
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   monaco-editor@0.52.2:
     resolution: {integrity: sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==}
@@ -904,6 +1124,10 @@ packages:
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
+  normalize-range@0.1.2:
+    resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
+    engines: {node: '>=0.10.0'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -917,6 +1141,9 @@ packages:
 
   pixi.js@7.4.3:
     resolution: {integrity: sha512-uIWdH0EI2dVgNoqN9aFaHCmR0V65OEhMkXs2sek3c/QP2ItV6UoM+ouX9esSv3ibo20F+J5D1XwnQhUZI6wqeQ==}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -980,6 +1207,17 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  tailwindcss@4.1.12:
+    resolution: {integrity: sha512-DzFtxOi+7NsFf7DBtI3BJsynR+0Yp6etH+nRPTbpWnS2pZBaSksv/JGctNwSWzbFjp0vxSqknaUylseZqMDGrA==}
+
+  tapable@2.2.3:
+    resolution: {integrity: sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==}
+    engines: {node: '>=6'}
+
+  tar@7.4.3:
+    resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
@@ -1046,6 +1284,10 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
   zod@4.1.5:
     resolution: {integrity: sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==}
 
@@ -1068,6 +1310,8 @@ packages:
         optional: true
 
 snapshots:
+
+  '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -1264,9 +1508,18 @@ snapshots:
   '@esbuild/win32-x64@0.25.9':
     optional: true
 
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.2
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.30
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.30
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -1530,6 +1783,78 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.49.0':
     optional: true
 
+  '@tailwindcss/node@4.1.12':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.18.3
+      jiti: 2.5.1
+      lightningcss: 1.30.1
+      magic-string: 0.30.18
+      source-map-js: 1.2.1
+      tailwindcss: 4.1.12
+
+  '@tailwindcss/oxide-android-arm64@4.1.12':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.12':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.1.12':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.12':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.12':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.12':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.12':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.12':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.12':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.1.12':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.12':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.12':
+    optional: true
+
+  '@tailwindcss/oxide@4.1.12':
+    dependencies:
+      detect-libc: 2.0.4
+      tar: 7.4.3
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.1.12
+      '@tailwindcss/oxide-darwin-arm64': 4.1.12
+      '@tailwindcss/oxide-darwin-x64': 4.1.12
+      '@tailwindcss/oxide-freebsd-x64': 4.1.12
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.1.12
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.1.12
+      '@tailwindcss/oxide-linux-arm64-musl': 4.1.12
+      '@tailwindcss/oxide-linux-x64-gnu': 4.1.12
+      '@tailwindcss/oxide-linux-x64-musl': 4.1.12
+      '@tailwindcss/oxide-wasm32-wasi': 4.1.12
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.1.12
+      '@tailwindcss/oxide-win32-x64-msvc': 4.1.12
+
+  '@tailwindcss/postcss@4.1.12':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.1.12
+      '@tailwindcss/oxide': 4.1.12
+      postcss: 8.5.6
+      tailwindcss: 4.1.12
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.28.3
@@ -1569,7 +1894,7 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
-  '@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@20.19.11))':
+  '@vitejs/plugin-react@4.7.0(vite@6.3.5(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1))':
     dependencies:
       '@babel/core': 7.28.3
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.3)
@@ -1577,11 +1902,21 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.5(@types/node@20.19.11)
+      vite: 6.3.5(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)
     transitivePeerDependencies:
       - supports-color
 
   '@xmldom/xmldom@0.8.11': {}
+
+  autoprefixer@10.4.21(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.25.4
+      caniuse-lite: 1.0.30001737
+      fraction.js: 4.3.7
+      normalize-range: 0.1.2
+      picocolors: 1.1.1
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
 
   browserslist@4.25.4:
     dependencies:
@@ -1602,6 +1937,8 @@ snapshots:
 
   caniuse-lite@1.0.30001737: {}
 
+  chownr@3.0.0: {}
+
   convert-source-map@2.0.0: {}
 
   csstype@3.1.3: {}
@@ -1609,6 +1946,8 @@ snapshots:
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
+
+  detect-libc@2.0.4: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -1619,6 +1958,11 @@ snapshots:
   earcut@2.2.4: {}
 
   electron-to-chromium@1.5.211: {}
+
+  enhanced-resolve@5.18.3:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.2.3
 
   es-define-property@1.0.1: {}
 
@@ -1665,6 +2009,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fraction.js@4.3.7: {}
+
   fsevents@2.3.3:
     optional: true
 
@@ -1692,6 +2038,8 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  graceful-fs@4.2.11: {}
+
   has-symbols@1.1.0: {}
 
   hasown@2.0.2:
@@ -1700,17 +2048,76 @@ snapshots:
 
   ismobilejs@1.1.1: {}
 
+  jiti@2.5.1: {}
+
   js-tokens@4.0.0: {}
 
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
 
+  lightningcss-darwin-arm64@1.30.1:
+    optional: true
+
+  lightningcss-darwin-x64@1.30.1:
+    optional: true
+
+  lightningcss-freebsd-x64@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.30.1:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.30.1:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.30.1:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.30.1:
+    optional: true
+
+  lightningcss@1.30.1:
+    dependencies:
+      detect-libc: 2.0.4
+    optionalDependencies:
+      lightningcss-darwin-arm64: 1.30.1
+      lightningcss-darwin-x64: 1.30.1
+      lightningcss-freebsd-x64: 1.30.1
+      lightningcss-linux-arm-gnueabihf: 1.30.1
+      lightningcss-linux-arm64-gnu: 1.30.1
+      lightningcss-linux-arm64-musl: 1.30.1
+      lightningcss-linux-x64-gnu: 1.30.1
+      lightningcss-linux-x64-musl: 1.30.1
+      lightningcss-win32-arm64-msvc: 1.30.1
+      lightningcss-win32-x64-msvc: 1.30.1
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
 
+  magic-string@0.30.18:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   math-intrinsics@1.1.0: {}
+
+  minipass@7.1.2: {}
+
+  minizlib@3.0.2:
+    dependencies:
+      minipass: 7.1.2
+
+  mkdirp@3.0.1: {}
 
   monaco-editor@0.52.2: {}
 
@@ -1719,6 +2126,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   node-releases@2.0.19: {}
+
+  normalize-range@0.1.2: {}
 
   object-inspect@1.13.4: {}
 
@@ -1758,6 +2167,8 @@ snapshots:
       '@pixi/text': 7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
       '@pixi/text-bitmap': 7.4.3(@pixi/assets@7.4.3(@pixi/core@7.4.3))(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/mesh@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))(@pixi/text@7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))))
       '@pixi/text-html': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))(@pixi/text@7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))))
+
+  postcss-value-parser@4.2.0: {}
 
   postcss@8.5.6:
     dependencies:
@@ -1846,6 +2257,19 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  tailwindcss@4.1.12: {}
+
+  tapable@2.2.3: {}
+
+  tar@7.4.3:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.0.2
+      mkdirp: 3.0.1
+      yallist: 5.0.0
+
   tinyglobby@0.2.14:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
@@ -1866,7 +2290,7 @@ snapshots:
       punycode: 1.4.1
       qs: 6.14.0
 
-  vite@6.3.5(@types/node@20.19.11):
+  vite@6.3.5(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
@@ -1877,8 +2301,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.11
       fsevents: 2.3.3
+      jiti: 2.5.1
+      lightningcss: 1.30.1
 
   yallist@3.1.1: {}
+
+  yallist@5.0.0: {}
 
   zod@4.1.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,12 +123,24 @@ importers:
 
   packages/studio:
     dependencies:
+      monaco-editor:
+        specifier: ^0.52.2
+        version: 0.52.2
       react:
         specifier: ^19.1.0
         version: 19.1.1
       react-dom:
         specifier: ^19.1.0
         version: 19.1.1(react@19.1.1)
+      react-monaco-editor:
+        specifier: ^0.58.0
+        version: 0.58.0(monaco-editor@0.52.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      zod:
+        specifier: ^4.1.5
+        version: 4.1.5
+      zustand:
+        specifier: ^5.0.8
+        version: 5.0.8(@types/react@19.1.12)(react@19.1.1)
     devDependencies:
       '@types/react':
         specifier: ^19.1.6
@@ -1034,6 +1046,27 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  zod@4.1.5:
+    resolution: {integrity: sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==}
+
+  zustand@5.0.8:
+    resolution: {integrity: sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@ampproject/remapping@2.3.0':
@@ -1846,3 +1879,10 @@ snapshots:
       fsevents: 2.3.3
 
   yallist@3.1.1: {}
+
+  zod@4.1.5: {}
+
+  zustand@5.0.8(@types/react@19.1.12)(react@19.1.1):
+    optionalDependencies:
+      '@types/react': 19.1.12
+      react: 19.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,12 @@ importers:
       monaco-editor:
         specifier: ^0.52.2
         version: 0.52.2
+      noxi.js:
+        specifier: workspace:*
+        version: link:../noxi.js
+      pixi.js:
+        specifier: ^7.4.0
+        version: 7.4.3
       react:
         specifier: ^19.1.0
         version: 19.1.1


### PR DESCRIPTION
## Summary
- add monaco-editor, react-monaco-editor, zustand, zod to studio
- define Project zod schema
- add zustand studio state with dirty flags and project actions

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2f4b11d38832aa5a5edc764fff1bf