### PR TITLE
feat(runtime): add observable and viewmodel

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -14,3 +14,5 @@ export type { Renderer, RenderImage, RenderText, RenderGraphics, RenderContainer
 export { Noxi } from './runtime.js';
 export { GuiObject } from './GuiObject.js';
 export * from './elements/ScrollViewer.js';
+export * from './observable.js';
+export * from './viewmodel.js';

--- a/packages/runtime/src/observable.ts
+++ b/packages/runtime/src/observable.ts
@@ -1,0 +1,20 @@
+export type Listener<T> = (value: T) => void;
+
+export class Observable<T> {
+  private listeners = new Set<Listener<T>>();
+
+  subscribe(fn: Listener<T>) {
+    this.listeners.add(fn);
+  }
+
+  unsubscribe(fn: Listener<T>) {
+    this.listeners.delete(fn);
+  }
+
+  notify(value: T) {
+    for (const fn of this.listeners) {
+      fn(value);
+    }
+  }
+}
+

--- a/packages/runtime/src/viewmodel.ts
+++ b/packages/runtime/src/viewmodel.ts
@@ -1,0 +1,22 @@
+import { Observable } from './observable.js';
+
+export type Change<T extends object> = { property: keyof T; value: T[keyof T] };
+
+export type ObservableObject<T extends object> = T & { observable: Observable<Change<T>> };
+
+export function ViewModel<T extends object>(obj: T): ObservableObject<T> {
+  const observable = new Observable<Change<T>>();
+  return new Proxy(obj as ObservableObject<T>, {
+    get(target, prop, receiver) {
+      if (prop === 'observable') return observable;
+      return Reflect.get(target, prop, receiver);
+    },
+    set(target, prop, value, receiver) {
+      if (prop === 'observable') return false;
+      const result = Reflect.set(target as any, prop, value, receiver);
+      observable.notify({ property: prop as keyof T, value } as Change<T>);
+      return result;
+    },
+  });
+}
+

--- a/packages/runtime/tests/viewmodel.test.ts
+++ b/packages/runtime/tests/viewmodel.test.ts
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Observable } from '../src/observable.js';
+import { ViewModel } from '../src/viewmodel.js';
+
+test('observable subscriptions', () => {
+  const obs = new Observable<number>();
+  let acc = 0;
+  const fn = (v: number) => { acc += v; };
+  obs.subscribe(fn);
+  obs.notify(5);
+  assert.equal(acc, 5);
+  obs.unsubscribe(fn);
+  obs.notify(5);
+  assert.equal(acc, 5);
+});
+
+test('viewmodel notifies on property changes', () => {
+  const vm = ViewModel({ a: 1 });
+  const events: Array<{ property: string; value: number }> = [];
+  vm.observable.subscribe((e) => events.push(e));
+  vm.a = 2;
+  assert.deepEqual(events, [{ property: 'a', value: 2 }]);
+});
+


### PR DESCRIPTION
## Summary
- add simple Observable class
- add ViewModel helper that notifies on property changes
- export Observable and ViewModel from runtime

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3f800bdcc832a9173c721ef12f08d