### PR TITLE
feat: add data context propagation to UIElement

### DIFF
--- a/packages/core/src/elements/UIElement.ts
+++ b/packages/core/src/elements/UIElement.ts
@@ -19,6 +19,8 @@ export abstract class UIElement {
   minW = 0; minH = 0;
   prefW?: number; prefH?: number;
 
+  private dataContext: unknown;
+
   /** Flag set when a new arrange pass is required. */
   arrangeDirty = false;
 
@@ -31,6 +33,26 @@ export abstract class UIElement {
   /** Marks this element as needing an arrange pass. */
   invalidateArrange() {
     this.arrangeDirty = true;
+  }
+
+  setDataContext(ctx: unknown) {
+    this.dataContext = ctx;
+    const kids = (this as any).children as UIElement[] | undefined;
+    if (kids) {
+      for (const k of kids) {
+        if ((k as any).dataContext === undefined) {
+          k.setDataContext(ctx);
+        }
+      }
+    }
+    const child = (this as any).child as UIElement | undefined;
+    if (child && (child as any).dataContext === undefined) {
+      child.setDataContext(ctx);
+    }
+  }
+
+  getDataContext() {
+    return this.dataContext;
   }
 
   protected measureAxis(axis: 'x' | 'y', avail: number, intrinsic: number): number {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,4 +2,4 @@ export * from './layout/engine.js';
 export * from './layout/register-defaults.js';
 export * from './layout/rules/basic.js';
 export * from './layout/rules/extra.js';
-export * from './elements/UIElement.js';
+export { UIElement, type Size, type Rect } from './elements/UIElement.js';

--- a/packages/runtime/tests/data-context.test.ts
+++ b/packages/runtime/tests/data-context.test.ts
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { StackPanel } from '../src/elements/StackPanel.js';
+import { UIElement } from '@noxigui/core';
+
+class Dummy extends UIElement {
+  measure() {}
+  arrange() {}
+}
+
+test('data context propagates to children', () => {
+  const sp = new StackPanel();
+  const a = new Dummy();
+  const b = new Dummy();
+  b.setDataContext('child');
+  sp.add(a);
+  sp.add(b);
+  sp.setDataContext('parent');
+  assert.equal(a.getDataContext(), 'parent');
+  assert.equal(b.getDataContext(), 'child');
+});


### PR DESCRIPTION
## Summary
- add data context store and accessor methods to `UIElement`
- export `UIElement` definitions in core index
- verify data context inheritance with a runtime test

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3f97ae540832a8bd606f7ea7e7221