### PR TITLE
feat: implement basic viewmodel bindings

### DIFF
--- a/packages/parser/src/Parser.ts
+++ b/packages/parser/src/Parser.ts
@@ -1,6 +1,6 @@
 import { UIElement, TemplateStore } from '@noxigui/runtime';
 import { createParsers as elementParsers } from './parsers/index.js';
-import type { Renderer, RenderContainer } from '@noxigui/runtime';
+import type { Renderer, RenderContainer, Binding } from '@noxigui/runtime';
 
 export interface XmlParser {
   parseFromString(xml: string, type: string): Document;
@@ -10,6 +10,7 @@ export interface XmlParser {
  * Parses NoxiGUI XML markup into UI elements and a PIXI display tree.
  */
 export class Parser {
+  bindings: Binding[] = [];
   /**
    * Create a new parser.
    *
@@ -27,14 +28,33 @@ export class Parser {
    *
    * @param node - DOM element to parse.
    * @returns The parsed UI element or `null` if no parser handled the node.
-   */
+  */
   parseElement(node: Element): UIElement | null {
     for (const p of this.parsers) {
       if (p.test(node)) {
-        return p.parse(node, this);
+        const el = p.parse(node, this);
+        if (el) this.parseBindings(node, el);
+        return el;
       }
     }
     return null;
+  }
+
+  private parseBindings(node: Element, el: UIElement) {
+    for (const attr of Array.from(node.attributes)) {
+      const val = attr.value.trim();
+      if (val.startsWith('{') && val.endsWith('}')) {
+        const inner = val.slice(1, -1).trim();
+        let path: string | null = null;
+        if (inner.startsWith('Binding')) {
+          const m = inner.match(/Binding\s+Path\s*=\s*(.+)/);
+          path = m ? m[1].trim() : null;
+        } else {
+          path = inner;
+        }
+        if (path) this.bindings.push({ element: el, property: attr.name, path });
+      }
+    }
   }
 
   /**
@@ -61,6 +81,6 @@ export class Parser {
     };
     collect(container, root);
 
-    return { root, container };
+    return { root, container, bindings: this.bindings };
   }
 }

--- a/packages/runtime/src/GuiObject.ts
+++ b/packages/runtime/src/GuiObject.ts
@@ -3,17 +3,21 @@ import { Grid } from './elements/Grid.js';
 import type { Renderer, RenderContainer } from './renderer.js';
 import { Parser } from '@noxigui/parser';
 import { TemplateStore } from './template.js';
+import type { Binding } from './binding.js';
+import type { ObservableObject, Change } from './viewmodel.js';
 
 export class GuiObject {
   public root: UIElement;
   public container: RenderContainer;
   public templates: TemplateStore;
+  private bindings: Binding[];
 
   constructor(xml: string, renderer: Renderer) {
     this.templates = new TemplateStore();
-    const { root, container } = new Parser(renderer, this.templates).parse(xml);
-    this.root = root;
-    this.container = container;
+    const parsed = new Parser(renderer, this.templates).parse(xml) as any;
+    this.root = parsed.root;
+    this.container = parsed.container;
+    this.bindings = parsed.bindings ?? [];
   }
 
   layout(size: Size) {
@@ -24,6 +28,16 @@ export class GuiObject {
   destroy() {
     const obj = this.container.getDisplayObject();
     (obj as any)?.destroy?.({ children: true });
+  }
+
+  bind(vm: ObservableObject<any>) {
+    for (const b of this.bindings) {
+      const apply = (value: any) => { (b.element as any)[b.property] = value; };
+      vm.observable.subscribe((change: Change<any>) => {
+        if (change.property === b.path) apply(change.value);
+      });
+      apply((vm as any)[b.path]);
+    }
   }
 
   setGridDebug(on: boolean) {

--- a/packages/runtime/src/binding.ts
+++ b/packages/runtime/src/binding.ts
@@ -1,0 +1,12 @@
+import type { UIElement } from '@noxigui/core';
+
+/** Describes a binding between a view model path and an element property. */
+export interface Binding {
+  /** Target element whose property should be updated. */
+  element: UIElement;
+  /** Property on the element to update. */
+  property: string;
+  /** View model path used to retrieve the value. */
+  path: string;
+}
+

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -16,3 +16,4 @@ export { GuiObject } from './GuiObject.js';
 export * from './elements/ScrollViewer.js';
 export * from './observable.js';
 export * from './viewmodel.js';
+export * from './binding.js';


### PR DESCRIPTION
## Summary
- add `Binding` descriptor to runtime
- parse attribute bindings like `{Binding Path=Foo}` or `{Foo}`
- apply bindings to view models in `GuiObject`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3fbadec2c832a9bf163f8e49c9ce8