### PR TITLE
Fix binding parsing and nested path resolution

### DIFF
--- a/packages/parser/src/Parser.ts
+++ b/packages/parser/src/Parser.ts
@@ -47,8 +47,13 @@ export class Parser {
         const inner = val.slice(1, -1).trim();
         let path: string | null = null;
         if (inner.startsWith('Binding')) {
-          const m = inner.match(/Binding\s+Path\s*=\s*(.+)/);
-          path = m ? m[1].trim() : null;
+          const rest = inner.slice('Binding'.length).trim();
+          if (rest.startsWith('Path')) {
+            const m = rest.match(/Path\s*=\s*(.+)/);
+            path = m ? m[1].trim() : null;
+          } else {
+            path = rest;
+          }
         } else {
           path = inner;
         }


### PR DESCRIPTION
## Summary
- support `{Binding ...}` syntax without `Path=` prefix in XML parser
- resolve nested property paths in GuiObject bindings

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3f512f0d0832a9c1a7816926f6c2a