### PR TITLE
Fix ItemsControl list binding to render items

### DIFF
--- a/packages/parser/src/parsers/ItemsControlParser.ts
+++ b/packages/parser/src/parsers/ItemsControlParser.ts
@@ -8,7 +8,7 @@ export class ItemsControlParser implements ElementParser {
   test(node: Element) { return node.tagName === 'ItemsControl'; }
 
   parse(node: Element, p: Parser) {
-    const ic = new ItemsControl();
+    const ic = new ItemsControl(p.renderer);
     parseSizeAttrs(node, ic);
     applyMargin(node, ic);
     applyGridAttachedProps(node, ic);
@@ -47,7 +47,8 @@ export class ItemsControlParser implements ElementParser {
 
   collect(into: RenderContainer, el: UIElement, collect: (into: RenderContainer, el: UIElement) => void) {
     if (el instanceof ItemsControl) {
-      collect(into, el.itemsPanel);
+      into.addChild(el.container.getDisplayObject());
+      el.setCollector(collect);
       return true;
     }
     return false;

--- a/packages/runtime/tests/items-control.test.ts
+++ b/packages/runtime/tests/items-control.test.ts
@@ -2,6 +2,48 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { ItemsControl } from '../src/elements/ItemsControl.js';
 import { UIElement } from '@noxigui/core';
+import type { Renderer } from '../src/renderer.js';
+
+const createRenderer = (): Renderer => ({
+  getTexture() { return undefined as any; },
+  createImage() { return {} as any; },
+  createText() {
+    return {
+      setWordWrap() {},
+      getBounds() { return { width: 0, height: 0 }; },
+      setPosition() {},
+      getDisplayObject() { return {}; },
+    } as any;
+  },
+  createGraphics() {
+    return {
+      clear() {},
+      beginFill() { return this; },
+      drawRect() { return this; },
+      endFill() {},
+      destroy() {},
+      getDisplayObject() { return {}; },
+    } as any;
+  },
+  createContainer() {
+    const obj = { children: [] as any[] };
+    return {
+      addChild(child: any) { obj.children.push(child); },
+      removeChild(child: any) {
+        const i = obj.children.indexOf(child);
+        if (i >= 0) obj.children.splice(i, 1);
+      },
+      setPosition() {},
+      setSortableChildren() {},
+      setMask() {},
+      addEventListener() {},
+      setEventMode() {},
+      setHitArea() {},
+      removeEventListener() {},
+      getDisplayObject() { return obj; },
+    } as any;
+  },
+});
 
 class Dummy extends UIElement {
   measure() {}
@@ -9,7 +51,7 @@ class Dummy extends UIElement {
 }
 
 test('items control regenerates children when source changes', () => {
-  const ic = new ItemsControl();
+  const ic = new ItemsControl(createRenderer());
   ic.itemTemplate = () => new Dummy();
   ic.itemsSource = [1, 2];
   const panel: any = ic.itemsPanel as any;


### PR DESCRIPTION
## Summary
- ensure ItemsControl collects item visuals into a render container
- update ItemsControl parser and tests to pass renderer and collector

## Testing
- `pnpm -F @noxigui/parser build`
- `pnpm -F @noxigui/runtime test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_68b41597dc24832ab93bfd8946fe7ad3