### PR TITLE
Fix ItemsControl render initialization timing

### DIFF
--- a/packages/parser/src/parsers/ItemsControlParser.ts
+++ b/packages/parser/src/parsers/ItemsControlParser.ts
@@ -49,6 +49,9 @@ export class ItemsControlParser implements ElementParser {
     if (el instanceof ItemsControl) {
       into.addChild(el.container.getDisplayObject());
       el.setCollector(collect);
+      // Mount the items panel so that any already-generated children
+      // participate in rendering immediately.
+      collect(el.container, el.itemsPanel);
       return true;
     }
     return false;

--- a/packages/runtime/src/elements/ItemsControl.ts
+++ b/packages/runtime/src/elements/ItemsControl.ts
@@ -24,6 +24,10 @@ export class ItemsControl extends ContentPresenter {
   /** Called by parser to enable collecting newly created items. */
   setCollector(fn: (into: RenderContainer, el: UIElement) => void) {
     this.collector = fn;
+    // If items were already generated before the collector was supplied
+    // (e.g. when bindings apply prior to collect phase), refresh to realize
+    // their render objects now.
+    this.refresh();
   }
 
   /** Panel used to layout generated item elements. */


### PR DESCRIPTION
## Summary
- refresh ItemsControl when collector is set so pre-bound items get their renders
- ensure ItemsControl parser collects the items panel during render tree assembly

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b450c80290832a849469ac860e2cff