### PR TITLE
feat(runtime): support deep viewmodel updates

### DIFF
--- a/packages/runtime/src/viewmodel.ts
+++ b/packages/runtime/src/viewmodel.ts
@@ -4,17 +4,42 @@ export type Change<T extends object> = { property: keyof T; value: T[keyof T] };
 
 export type ObservableObject<T extends object> = T & { observable: Observable<Change<T>> };
 
+/**
+ * Wrap an object in a proxy that notifies on property assignments. Nested
+ * objects and arrays are automatically wrapped so that changes to deep fields
+ * also trigger notifications.
+ */
 export function ViewModel<T extends object>(obj: T): ObservableObject<T> {
   const observable = new Observable<Change<T>>();
+
+  const wrap = (val: any): any => {
+    if (val && typeof val === 'object' && !(val as any).observable) {
+      return ViewModel(val);
+    }
+    return val;
+  };
+
+  const init = (o: any) => {
+    if (Array.isArray(o)) {
+      for (let i = 0; i < o.length; i++) o[i] = wrap(o[i]);
+    } else {
+      for (const k of Object.keys(o)) o[k] = wrap(o[k]);
+    }
+  };
+
+  init(obj);
+
   return new Proxy(obj as ObservableObject<T>, {
     get(target, prop, receiver) {
       if (prop === 'observable') return observable;
-      return Reflect.get(target, prop, receiver);
+      const value = Reflect.get(target, prop, receiver);
+      return wrap(value);
     },
     set(target, prop, value, receiver) {
       if (prop === 'observable') return false;
-      const result = Reflect.set(target as any, prop, value, receiver);
-      observable.notify({ property: prop as keyof T, value } as Change<T>);
+      const wrapped = wrap(value);
+      const result = Reflect.set(target as any, prop, wrapped, receiver);
+      observable.notify({ property: prop as keyof T, value: wrapped } as Change<T>);
       return result;
     },
   });

--- a/packages/runtime/tests/playground-schema.test.ts
+++ b/packages/runtime/tests/playground-schema.test.ts
@@ -264,4 +264,28 @@ test('playground App layout parses and binds correctly', () => {
 
   const firstCard: any = panel.children[0];
   assert.deepEqual(firstCard.getDataContext(), vm.Inventory[0]);
+
+  // Runtime updates to data should update displayed text and image
+  const updatedItem = { Title: 'Platinum Ore', Source: 'gold_ore' };
+  vm.Inventory = [updatedItem, ...vm.Inventory.slice(1)];
+  vm.Stats.Health = 150;
+
+  gui.layout({ width: 800, height: 600 });
+
+  // updated stat value should be rendered
+  const textsAfter = collectTexts(gui.root).map(t => String(t.text));
+  assert.ok(textsAfter.includes('150'), 'updated stat not displayed');
+
+  // first card should reflect new item data
+  assert.equal(panel.children.length, vm.Inventory.length);
+  const updatedCard: any = panel.children[0];
+  const updatedTexts = collectTexts(updatedCard).map(t => String(t.text));
+  assert.ok(updatedTexts.includes(updatedItem.Title), 'updated card missing new text');
+
+  const updatedImgEl = findImage(updatedCard);
+  assert.ok(updatedImgEl, 'updated card missing image after change');
+  const updatedTex = imageTextures.get(updatedImgEl.sprite.getDisplayObject());
+  const expectedTex = renderer.getTexture(updatedItem.Source);
+  assert.equal(updatedTex, expectedTex, 'updated card wrong texture');
+
 });


### PR DESCRIPTION
## Summary
- allow ViewModel to observe nested objects and arrays
- extend playground schema test to verify runtime data updates propagate to UI

## Testing
- `pnpm -F @noxigui/runtime test`


------
https://chatgpt.com/codex/tasks/task_e_68b4722ef184832ab7165065c7467c6c