### PR TITLE
feat: enable multi-select drag in asset tree

### DIFF
--- a/packages/studio/src/ui/panels/AssetsPanel.tsx
+++ b/packages/studio/src/ui/panels/AssetsPanel.tsx
@@ -1,125 +1,139 @@
-import React, { useEffect, useRef, useState } from "react";
-import { Plus, FolderPlus } from "lucide-react";
-import Tree, { type TreeItem, type DropPosition } from "../tree/Tree";
-import { useStudio } from "../../state/useStudio";
+import React, { useEffect, useRef, useState } from 'react'
+import { Plus, FolderPlus } from 'lucide-react'
+import Tree, { type TreeItem, type DropPosition } from '../tree/Tree'
+import { useStudio } from '../../state/useStudio'
 
 // === Вспомогалки ===
-const makeUnique = (base: string, taken: Set<string>, sep = "-") => {
-  if (!taken.has(base)) return base;
-  let i = 2;
-  while (taken.has(`${base}${sep}${i}`)) i++;
-  return `${base}${sep}${i}`;
-};
+const makeUnique = (base: string, taken: Set<string>, sep = '-') => {
+  if (!taken.has(base)) return base
+  let i = 2
+  while (taken.has(`${base}${sep}${i}`)) i++
+  return `${base}${sep}${i}`
+}
 
 const parentPath = (full: string) => {
-  const parts = full.split("/").filter(Boolean);
-  parts.pop();
-  return parts.join("/");
-};
-const leafName = (full: string) => full.split("/").filter(Boolean).pop() ?? "";
+  const parts = full.split('/').filter(Boolean)
+  parts.pop()
+  return parts.join('/')
+}
+const leafName = (full: string) => full.split('/').filter(Boolean).pop() ?? ''
 
 // file -> dataURL, чтобы жить без бэкенда
 const fileToDataURL = (file: File) =>
   new Promise<string>((res, rej) => {
-    const r = new FileReader();
-    r.onload = () => res(String(r.result));
-    r.onerror = rej;
-    r.readAsDataURL(file);
-  });
+    const r = new FileReader()
+    r.onload = () => res(String(r.result))
+    r.onerror = rej
+    r.readAsDataURL(file)
+  })
 
 // Построение дерева из проекта
 function buildAssetsRoot(project: {
-  assets: Array<{ alias: string; src: string; name?: string }>;
-  meta?: { assetFolders?: string[]; assetPaths?: Record<string, string> };
+  assets: Array<{ alias: string; src: string; name?: string }>
+  meta?: { assetFolders?: string[]; assetPaths?: Record<string, string> }
 }): TreeItem {
-  const root: TreeItem = { id: "assets-root", name: "Assets", type: "folder", children: [] };
-  const folders = new Set(project.meta?.assetFolders ?? []);
-  const assetPaths = project.meta?.assetPaths ?? {};
+  const root: TreeItem = {
+    id: 'assets-root',
+    name: 'Assets',
+    type: 'folder',
+    children: [],
+  }
+  const folders = new Set(project.meta?.assetFolders ?? [])
+  const assetPaths = project.meta?.assetPaths ?? {}
 
   // индекс папок по пути
-  const byPath = new Map<string, TreeItem>();
+  const byPath = new Map<string, TreeItem>()
   const ensureFolder = (fullPath: string): TreeItem => {
-    if (byPath.has(fullPath)) return byPath.get(fullPath)!;
-    const parts = fullPath.split("/").filter(Boolean);
-    let cursor = root;
-    let acc = "";
+    if (byPath.has(fullPath)) return byPath.get(fullPath)!
+    const parts = fullPath.split('/').filter(Boolean)
+    let cursor = root
+    let acc = ''
     for (const part of parts) {
-      acc = acc ? `${acc}/${part}` : part;
-      let next = byPath.get(acc);
+      acc = acc ? `${acc}/${part}` : part
+      let next = byPath.get(acc)
       if (!next) {
-        next = { id: `folder:${acc}`, name: part, type: "folder", children: [] };
-        cursor.children = cursor.children ?? [];
-        cursor.children.push(next);
-        byPath.set(acc, next);
+        next = { id: `folder:${acc}`, name: part, type: 'folder', children: [] }
+        cursor.children = cursor.children ?? []
+        cursor.children.push(next)
+        byPath.set(acc, next)
       }
-      cursor = next;
+      cursor = next
     }
-    return cursor;
-  };
+    return cursor
+  }
 
   // 1) папки
-  for (const p of folders) if (p.trim()) ensureFolder(p.trim());
+  for (const p of folders) if (p.trim()) ensureFolder(p.trim())
 
   // 2) ассеты
   for (const a of project.assets ?? []) {
-    const display = a.name ?? a.alias;
-    const node: TreeItem = { id: `asset:${a.alias}`, name: display, type: "image" };
-    const p = (assetPaths[a.alias] || "").trim();
-    if (p) ensureFolder(p).children!.push(node);
+    const display = a.name ?? a.alias
+    const node: TreeItem = {
+      id: `asset:${a.alias}`,
+      name: display,
+      type: 'image',
+    }
+    const p = (assetPaths[a.alias] || '').trim()
+    if (p) ensureFolder(p).children!.push(node)
     else {
-      root.children = root.children ?? [];
-      root.children.push(node);
+      root.children = root.children ?? []
+      root.children.push(node)
     }
   }
-  return root;
+  return root
 }
 
 // локальный dnd для UI (persist делаем отдельно)
 function extractNode(arr: TreeItem[], id: string): TreeItem | null {
   for (let i = 0; i < arr.length; i++) {
-    const it = arr[i];
+    const it = arr[i]
     if (it.id === id) {
-      arr.splice(i, 1);
-      return it;
+      arr.splice(i, 1)
+      return it
     }
     if (it.children) {
-      const got = extractNode(it.children, id);
-      if (got) return got;
+      const got = extractNode(it.children, id)
+      if (got) return got
     }
   }
-  return null;
+  return null
 }
-function moveNode(root: TreeItem, sourceId: string, targetId: string, pos: DropPosition): TreeItem {
-  const clone: TreeItem = structuredClone(root);
-  const src = extractNode(clone.children ?? [], sourceId);
-  if (!src) return clone;
+function moveNode(
+  root: TreeItem,
+  sourceId: string,
+  targetId: string,
+  pos: DropPosition,
+): TreeItem {
+  const clone: TreeItem = structuredClone(root)
+  const src = extractNode(clone.children ?? [], sourceId)
+  if (!src) return clone
 
   if (targetId === root.id) {
-    clone.children = clone.children ?? [];
-    pos === "before" ? clone.children.unshift(src) : clone.children.push(src);
-    return clone;
+    clone.children = clone.children ?? []
+    pos === 'before' ? clone.children.unshift(src) : clone.children.push(src)
+    return clone
   }
   const insert = (arr: TreeItem[], parent: TreeItem | null): boolean => {
     for (let i = 0; i < arr.length; i++) {
-      const it = arr[i];
+      const it = arr[i]
       if (it.id === targetId) {
-        if (pos === "inside") {
-          it.children = it.children ?? [];
-          it.children.push(src);
-          return true;
+        if (pos === 'inside') {
+          it.children = it.children ?? []
+          it.children.push(src)
+          return true
         }
-        const siblings = parent ? parent.children! : arr;
-        const idx = siblings.findIndex((n) => n.id === targetId);
-        const at = pos === "before" ? idx : idx + 1;
-        siblings.splice(at, 0, src);
-        return true;
+        const siblings = parent ? parent.children! : arr
+        const idx = siblings.findIndex((n) => n.id === targetId)
+        const at = pos === 'before' ? idx : idx + 1
+        siblings.splice(at, 0, src)
+        return true
       }
-      if (it.children && insert(it.children, it)) return true;
+      if (it.children && insert(it.children, it)) return true
     }
-    return false;
-  };
-  insert(clone.children ?? [], null);
-  return clone;
+    return false
+  }
+  insert(clone.children ?? [], null)
+  return clone
 }
 
 // === Панель ассетов ===
@@ -133,118 +147,122 @@ export function AssetsPanel() {
     deleteAsset,
     renameAssetFolder,
     deleteAssetFolder,
-  } = useStudio();
+  } = useStudio()
 
-  const [root, setRoot] = useState<TreeItem>(() => buildAssetsRoot(project));
-  const [expanded, setExpanded] = useState<Set<string>>(new Set(["assets-root"]));
-  const [selected, setSelected] = useState<string | null>(null);
+  const [root, setRoot] = useState<TreeItem>(() => buildAssetsRoot(project))
+  const [expanded, setExpanded] = useState<Set<string>>(
+    new Set(['assets-root']),
+  )
+  const [selected, setSelected] = useState<Set<string>>(new Set())
 
   // Перестраиваем при изменении проекта
   useEffect(() => {
-    setRoot(buildAssetsRoot(project));
-  }, [project.assets, project.meta?.assetFolders, project.meta?.assetPaths]);
+    setRoot(buildAssetsRoot(project))
+  }, [project.assets, project.meta?.assetFolders, project.meta?.assetPaths])
 
-  const visible = [root];
+  const visible = [root]
 
   // input для добавления картинок
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
 
   // Добавить картинки: ПЕРЕЗАПИСЫВАЕМ существующий alias, а не делаем -2
   const onAddFiles = async (files: FileList | null) => {
-    if (!files) return;
+    if (!files) return
 
-    const existing = project.assets ?? [];
-    const nextAssets = [...existing];
-    const byAlias = new Map(existing.map((a) => [a.alias, a]));
+    const existing = project.assets ?? []
+    const nextAssets = [...existing]
+    const byAlias = new Map(existing.map((a) => [a.alias, a]))
 
     for (let i = 0; i < files.length; i++) {
-      const f = files[i];
-      if (!f.type.startsWith("image/")) continue;
+      const f = files[i]
+      if (!f.type.startsWith('image/')) continue
 
-      const dataUrl = await fileToDataURL(f);
-      const rawBase = f.name.replace(/\.[^.]+$/, ""); // "hero" из "hero.png"
-      const alias = rawBase;                           // КЛЮЧЕВОЕ: НЕ уникализируем
+      const dataUrl = await fileToDataURL(f)
+      const rawBase = f.name.replace(/\.[^.]+$/, '') // "hero" из "hero.png"
+      const alias = rawBase // КЛЮЧЕВОЕ: НЕ уникализируем
 
-      const existed = byAlias.get(alias);
+      const existed = byAlias.get(alias)
       if (existed) {
-        existed.src = dataUrl;      // overwrite src
-        if (!existed.name) existed.name = f.name;
+        existed.src = dataUrl // overwrite src
+        if (!existed.name) existed.name = f.name
       } else {
-        const asset = { alias, src: dataUrl, name: f.name };
-        nextAssets.push(asset);
-        byAlias.set(alias, asset);
+        const asset = { alias, src: dataUrl, name: f.name }
+        nextAssets.push(asset)
+        byAlias.set(alias, asset)
       }
     }
 
-    setAssets(nextAssets);
-  };
+    setAssets(nextAssets)
+  }
 
   // Новая папка (в корне)
   const onNewFolder = () => {
-    const base = "New Folder";
+    const base = 'New Folder'
     const siblings = new Set(
       (project.meta?.assetFolders ?? [])
-        .filter((p) => !p.includes("/"))
-        .map((p) => leafName(p))
-    );
-    const leaf = makeUnique(base, siblings, " ");
-    addAssetFolder(leaf);
-  };
+        .filter((p) => !p.includes('/'))
+        .map((p) => leafName(p)),
+    )
+    const leaf = makeUnique(base, siblings, ' ')
+    addAssetFolder(leaf)
+  }
 
   // DnD: persist путей при броске
-  const handleDrop = (src: string, dst: string, pos: DropPosition) => {
-    if (src === dst) return;
-
-    setRoot((r) => moveNode(r, src, dst, pos));
-
-    const isAsset = src.startsWith("asset:");
-    const alias = isAsset ? src.slice("asset:".length) : "";
-
-    if (isAsset) {
-      if (dst.startsWith("folder:") && pos === "inside") {
-        const folderPath = dst.slice("folder:".length);
-        setAssetPath(alias, folderPath || null);
-      } else if (dst === "assets-root") {
-        setAssetPath(alias, null);
+  const handleDrop = (srcIds: string[], dst: string, pos: DropPosition) => {
+    setRoot((r) => {
+      let next = r
+      for (const src of srcIds) {
+        if (src === dst) continue
+        next = moveNode(next, src, dst, pos)
+        if (src.startsWith('asset:')) {
+          const alias = src.slice('asset:'.length)
+          if (dst.startsWith('folder:') && pos === 'inside') {
+            const folderPath = dst.slice('folder:'.length)
+            setAssetPath(alias, folderPath || null)
+          } else if (dst === 'assets-root') {
+            setAssetPath(alias, null)
+          }
+        }
       }
-    }
-  };
+      return next
+    })
+  }
 
   // Переименование
   const handleRename = (id: string, nextName: string) => {
-    if (id.startsWith("asset:")) {
-      const alias = id.slice("asset:".length);
-      renameAssetDisplayName(alias, nextName);
-      return;
+    if (id.startsWith('asset:')) {
+      const alias = id.slice('asset:'.length)
+      renameAssetDisplayName(alias, nextName)
+      return
     }
-    if (id.startsWith("folder:")) {
-      const full = id.slice("folder:".length);
-      const parent = parentPath(full);
+    if (id.startsWith('folder:')) {
+      const full = id.slice('folder:'.length)
+      const parent = parentPath(full)
       const siblingLeaves = new Set(
         (project.meta?.assetFolders ?? [])
           .filter((p) => parentPath(p) === parent)
-          .map((p) => leafName(p))
-      );
-      const uniqueLeaf = makeUnique(nextName, siblingLeaves, " ");
-      const newFull = parent ? `${parent}/${uniqueLeaf}` : uniqueLeaf;
+          .map((p) => leafName(p)),
+      )
+      const uniqueLeaf = makeUnique(nextName, siblingLeaves, ' ')
+      const newFull = parent ? `${parent}/${uniqueLeaf}` : uniqueLeaf
       if (newFull !== full) {
-        renameAssetFolder(full, newFull);
+        renameAssetFolder(full, newFull)
       }
     }
-  };
+  }
 
   // Удаление
   const handleDelete = (id: string) => {
-    if (id.startsWith("asset:")) {
-      const alias = id.slice("asset:".length);
-      deleteAsset(alias);
-      return;
+    if (id.startsWith('asset:')) {
+      const alias = id.slice('asset:'.length)
+      deleteAsset(alias)
+      return
     }
-    if (id.startsWith("folder:")) {
-      const full = id.slice("folder:".length);
-      deleteAssetFolder(full);
+    if (id.startsWith('folder:')) {
+      const full = id.slice('folder:'.length)
+      deleteAssetFolder(full)
     }
-  };
+  }
 
   return (
     <div className="h-full overflow-auto">
@@ -282,12 +300,12 @@ export function AssetsPanel() {
         <Tree
           items={visible}
           expanded={expanded}
-          selectedId={selected}
+          selected={selected}
           onToggle={(id) =>
             setExpanded((prev) => {
-              const next = new Set(prev);
-              next.has(id) ? next.delete(id) : next.add(id);
-              return next;
+              const next = new Set(prev)
+              next.has(id) ? next.delete(id) : next.add(id)
+              return next
             })
           }
           onSelect={setSelected}
@@ -295,12 +313,12 @@ export function AssetsPanel() {
           onRename={handleRename}
           onDelete={handleDelete}
           allowDrop={(src, dst, pos) => {
-            if (src.id === dst.id) return false;
-            if (pos === "inside") return dst.type === "folder";
-            return true;
+            if (src.id === dst.id) return false
+            if (pos === 'inside') return dst.type === 'folder'
+            return true
           }}
         />
       </div>
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- allow selecting multiple tree items via Shift/Ctrl
- support dragging multiple assets at once

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b573aef980832ab4514812e4b370cb