### PR TITLE
feat(studio): add undo/redo for assets

### DIFF
--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "pretest": "tsc -p tsconfig.test.json",
+    "test": "if ls dist/tests/*.test.js 1> /dev/null 2>&1; then node --test dist/tests/*.test.js; else echo 'no tests'; fi"
   },
   "dependencies": {
     "fast-json-patch": "^3.1.1",
@@ -23,6 +25,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.12",
+    "@types/node": "^24.3.0",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.5.1",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -9,16 +9,17 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "fast-json-patch": "^3.1.1",
+    "idb-keyval": "^6.2.2",
+    "lucide-react": "^0.542.0",
     "monaco-editor": "^0.52.2",
+    "noxi.js": "workspace:*",
+    "pixi.js": "^7.4.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-monaco-editor": "^0.58.0",
     "zod": "^4.1.5",
-    "zustand": "^5.0.8",
-    "pixi.js": "^7.4.0",
-    "noxi.js": "workspace:*",
-    "lucide-react": "^0.542.0",
-    "idb-keyval": "^6.2.2"
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.12",

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from "react";
+import React, { useEffect } from "react";
 import { useStudio } from "./state/useStudio";
 import { AppShell } from "./ui/AppShell";
 import { Sidebar } from "./ui/Sidebar";
@@ -25,7 +25,26 @@ export default function App() {
     setTab,
     newProject,
     renameProject, // ← добавь в стор, если ещё нет
+    undo,
+    redo,
   } = useStudio() as any;
+
+  useEffect(() => {
+    const isTextInput = (el: any) =>
+      el.tagName === 'INPUT' ||
+      el.tagName === 'TEXTAREA' ||
+      el.isContentEditable ||
+      el.closest?.('.monaco-editor');
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'z') {
+        if (isTextInput(e.target as HTMLElement)) return;
+        e.preventDefault();
+        e.shiftKey ? redo() : undo();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [undo, redo]);
 
   const onImport = async () => { /* твой код */ };
   const onExport = () => { /* твой код */ };

--- a/packages/studio/src/state/storage.ts
+++ b/packages/studio/src/state/storage.ts
@@ -1,6 +1,6 @@
 // storage.ts
 import { get, set, del, keys } from "idb-keyval";
-import type { Project } from "../types/project";
+import type { Project } from "../types/project.js";
 
 const PROJECT_KEY = "noxigui:project:v2";
 const ASSET_PREFIX = "noxigui:asset:";

--- a/packages/studio/src/state/useStudio.ts
+++ b/packages/studio/src/state/useStudio.ts
@@ -1,13 +1,14 @@
 // src/state/useStudio.ts
 import { create } from "zustand";
-import { ProjectZ } from "../types/project";
-import type { Project } from "../types/project";
+import { ProjectZ } from "../types/project.js";
+import type { Project } from "../types/project.js";
 import {
   saveProjectToIDB,
   loadProjectFromIDB,
   deleteMissingAssetBlobs,
-} from "./storage";
-import { applyPatch, compare } from "fast-json-patch";
+} from "./storage.js";
+import jsonPatch from "fast-json-patch";
+const { applyPatch, compare } = jsonPatch;
 
 export const defaultProject: Project = {
   name: "Untitled",

--- a/packages/studio/src/state/useStudio.ts
+++ b/packages/studio/src/state/useStudio.ts
@@ -47,6 +47,7 @@ type StudioState = {
   setLayout: (s: string) => void;
   setData: (o: any) => void;
   setAssets: (a: Project["assets"]) => void;
+  addAssets: (a: Project["assets"]) => void;
 
   // canvas
   canvas: { width: number; height: number };
@@ -196,6 +197,23 @@ export const useStudio = create<StudioState>((set, get) => {
 
     setAssets: (assets) =>
       runProjectCommand((p) => ({ ...p, assets })),
+
+    addAssets: (toAdd) =>
+      runProjectCommand((p) => {
+        const assets = [...(p.assets ?? [])];
+        const byAlias = new Map(assets.map((a) => [a.alias, a]));
+        for (const asset of toAdd) {
+          const existing = byAlias.get(asset.alias);
+          if (existing) {
+            existing.src = asset.src;
+            if (!existing.name) existing.name = asset.name;
+          } else {
+            assets.push(asset);
+            byAlias.set(asset.alias, asset);
+          }
+        }
+        return { ...p, assets };
+      }),
 
     // ===== Canvas =====
     setCanvasSize: (width, height) =>

--- a/packages/studio/src/state/useStudio.ts
+++ b/packages/studio/src/state/useStudio.ts
@@ -58,6 +58,7 @@ type StudioState = {
   addAssetFolder: (path: string) => void;
   setAssetPath: (alias: string, path: string | null) => void; // null => в корень
   renameAssetDisplayName: (alias: string, name: string) => void; // только display name (НЕ alias)
+  deleteAssets: (aliases: string[]) => void;
   deleteAsset: (alias: string) => void;
 
   renameAssetFolder: (oldPath: string, newPath: string) => void; // переносит подпапки/ассеты
@@ -271,16 +272,19 @@ export const useStudio = create<StudioState>((set, get) => {
         return { ...p, assets };
       }),
 
-    deleteAsset: (alias) =>
+    deleteAssets: (aliases) =>
       runProjectCommand((p) => {
-        const assets = (p.assets ?? []).filter((a) => a.alias !== alias);
+        const remove = new Set(aliases);
+        const assets = (p.assets ?? []).filter((a) => !remove.has(a.alias));
         const meta = {
           ...(p.meta ?? {}),
           assetPaths: { ...(p.meta?.assetPaths ?? {}) },
         };
-        delete meta.assetPaths[alias];
+        for (const alias of aliases) delete meta.assetPaths[alias];
         return { ...p, assets, meta };
       }),
+
+    deleteAsset: (alias) => get().deleteAssets([alias]),
 
     renameAssetFolder: (oldPath, newPath) =>
       runProjectCommand((p) => {

--- a/packages/studio/src/ui/panels/AssetsPanel.tsx
+++ b/packages/studio/src/ui/panels/AssetsPanel.tsx
@@ -144,7 +144,7 @@ export function AssetsPanel() {
     addAssetFolder,
     setAssetPath,
     renameAssetDisplayName,
-    deleteAsset,
+    deleteAssets,
     renameAssetFolder,
     deleteAssetFolder,
   } = useStudio()
@@ -242,7 +242,7 @@ export function AssetsPanel() {
     (id: string) => {
       if (id.startsWith('asset:')) {
         const alias = id.slice('asset:'.length)
-        deleteAsset(alias)
+        deleteAssets([alias])
         return
       }
       if (id.startsWith('folder:')) {
@@ -250,19 +250,26 @@ export function AssetsPanel() {
         deleteAssetFolder(full)
       }
     },
-    [deleteAsset, deleteAssetFolder],
+    [deleteAssets, deleteAssetFolder],
   )
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Delete') {
-        for (const id of Array.from(selected)) handleDelete(id)
+        const assets: string[] = []
+        const folders: string[] = []
+        for (const id of Array.from(selected)) {
+          if (id.startsWith('asset:')) assets.push(id.slice('asset:'.length))
+          else if (id.startsWith('folder:')) folders.push(id.slice('folder:'.length))
+        }
+        if (assets.length) deleteAssets(assets)
+        for (const full of folders) deleteAssetFolder(full)
         if (selected.size) setSelected(new Set())
       }
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [selected, handleDelete])
+  }, [selected, deleteAssets, deleteAssetFolder])
 
   return (
     <div className="h-full overflow-auto p-2 text-sm">

--- a/packages/studio/src/ui/panels/AssetsPanel.tsx
+++ b/packages/studio/src/ui/panels/AssetsPanel.tsx
@@ -140,7 +140,7 @@ function moveNode(
 export function AssetsPanel() {
   const {
     project,
-    setAssets,
+    addAssets,
     addAssetFolder,
     setAssetPath,
     renameAssetDisplayName,
@@ -168,31 +168,17 @@ export function AssetsPanel() {
   // Добавить картинки: ПЕРЕЗАПИСЫВАЕМ существующий alias, а не делаем -2
   const onAddFiles = async (files: FileList | null) => {
     if (!files) return
-
-    const existing = project.assets ?? []
-    const nextAssets = [...existing]
-    const byAlias = new Map(existing.map((a) => [a.alias, a]))
-
+    const toAdd: Array<{ alias: string; src: string; name: string }> = []
     for (let i = 0; i < files.length; i++) {
       const f = files[i]
       if (!f.type.startsWith('image/')) continue
-
       const dataUrl = await fileToDataURL(f)
       const rawBase = f.name.replace(/\.[^.]+$/, '') // "hero" из "hero.png"
       const alias = rawBase // КЛЮЧЕВОЕ: НЕ уникализируем
-
-      const existed = byAlias.get(alias)
-      if (existed) {
-        existed.src = dataUrl // overwrite src
-        if (!existed.name) existed.name = f.name
-      } else {
-        const asset = { alias, src: dataUrl, name: f.name }
-        nextAssets.push(asset)
-        byAlias.set(alias, asset)
-      }
+      toAdd.push({ alias, src: dataUrl, name: f.name })
     }
 
-    setAssets(nextAssets)
+    addAssets(toAdd)
   }
 
   // Новая папка (в корне)

--- a/packages/studio/src/ui/panels/AssetsPanel.tsx
+++ b/packages/studio/src/ui/panels/AssetsPanel.tsx
@@ -147,6 +147,8 @@ export function AssetsPanel() {
     deleteAssets,
     renameAssetFolder,
     deleteAssetFolder,
+    selectAssetAliases,
+    clearSelectAssetAliases,
   } = useStudio()
 
   const [root, setRoot] = useState<TreeItem>(() => buildAssetsRoot(project))
@@ -154,6 +156,12 @@ export function AssetsPanel() {
     new Set(['assets-root']),
   )
   const [selected, setSelected] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    if (selectAssetAliases === null) return
+    setSelected(new Set(selectAssetAliases.map((a) => `asset:${a}`)))
+    clearSelectAssetAliases()
+  }, [selectAssetAliases, clearSelectAssetAliases])
 
   // Перестраиваем при изменении проекта
   useEffect(() => {

--- a/packages/studio/tests/undo-redo.test.ts
+++ b/packages/studio/tests/undo-redo.test.ts
@@ -38,6 +38,22 @@ test('undo/redo removes added asset', () => {
   assert.equal(useStudio.getState().project.assets.length, 1);
 });
 
+test('undo/redo restores multiple deleted assets at once', () => {
+  reset();
+  const store = useStudio.getState();
+  store.addAssets([
+    { alias: 'a1', name: '', src: '' },
+    { alias: 'a2', name: '', src: '' },
+  ]);
+  assert.equal(useStudio.getState().project.assets.length, 2);
+  store.deleteAssets(['a1', 'a2']);
+  assert.equal(useStudio.getState().project.assets.length, 0);
+  store.undo();
+  assert.equal(useStudio.getState().project.assets.length, 2);
+  store.redo();
+  assert.equal(useStudio.getState().project.assets.length, 0);
+});
+
 test('new command clears redo stack', () => {
   reset();
   const store = useStudio.getState();

--- a/packages/studio/tests/undo-redo.test.ts
+++ b/packages/studio/tests/undo-redo.test.ts
@@ -17,7 +17,7 @@ function reset() {
 test('undo/redo restores deleted asset', () => {
   reset();
   const store = useStudio.getState();
-  store.setAssets([{ alias: 'hero', name: 'Hero', src: '' }]);
+  store.addAssets([{ alias: 'hero', name: 'Hero', src: '' }]);
   assert.equal(useStudio.getState().project.assets.length, 1);
   store.deleteAsset('hero');
   assert.equal(useStudio.getState().project.assets.length, 0);
@@ -27,23 +27,40 @@ test('undo/redo restores deleted asset', () => {
   assert.equal(useStudio.getState().project.assets.length, 0);
 });
 
+test('undo/redo removes added asset', () => {
+  reset();
+  const store = useStudio.getState();
+  store.addAssets([{ alias: 'hero', name: 'Hero', src: '' }]);
+  assert.equal(useStudio.getState().project.assets.length, 1);
+  store.undo();
+  assert.equal(useStudio.getState().project.assets.length, 0);
+  store.redo();
+  assert.equal(useStudio.getState().project.assets.length, 1);
+});
+
 test('new command clears redo stack', () => {
   reset();
   const store = useStudio.getState();
-  store.setAssets([{ alias: 'a1', name: '', src: '' }]);
-  store.setAssets([{ alias: 'a2', name: '', src: '' }]);
+  store.addAssets([{ alias: 'a1', name: '', src: '' }]);
+  store.addAssets([{ alias: 'a2', name: '', src: '' }]);
   store.undo();
-  assert.equal(useStudio.getState().project.assets[0].alias, 'a1');
-  store.setAssets([{ alias: 'a3', name: '', src: '' }]);
+  assert.deepEqual(
+    useStudio.getState().project.assets.map((a) => a.alias),
+    ['a1'],
+  );
+  store.addAssets([{ alias: 'a3', name: '', src: '' }]);
   store.redo();
-  assert.equal(useStudio.getState().project.assets[0].alias, 'a3');
+  assert.deepEqual(
+    useStudio.getState().project.assets.map((a) => a.alias),
+    ['a1', 'a3'],
+  );
 });
 
 test('history capped at 10 commands', () => {
   reset();
   const store = useStudio.getState();
   for (let i = 1; i <= 11; i++) {
-    store.setAssets([{ alias: `a${i}`, name: '', src: '' }]);
+    store.addAssets([{ alias: `a${i}`, name: '', src: '' }]);
   }
   for (let i = 0; i < 11; i++) {
     store.undo();

--- a/packages/studio/tests/undo-redo.test.ts
+++ b/packages/studio/tests/undo-redo.test.ts
@@ -11,6 +11,7 @@ function reset() {
     activeTab: 'Layout',
     dirty: { layout: false, data: false, assets: false },
     canvas: { width: 1280, height: 720 },
+    selectAssetAliases: null,
   });
 }
 
@@ -52,6 +53,18 @@ test('undo/redo restores multiple deleted assets at once', () => {
   assert.equal(useStudio.getState().project.assets.length, 2);
   store.redo();
   assert.equal(useStudio.getState().project.assets.length, 0);
+});
+
+test('undoing deletion selects restored assets', () => {
+  reset();
+  const store = useStudio.getState();
+  store.addAssets([{ alias: 'hero', name: '', src: '' }]);
+  store.deleteAsset('hero');
+  assert.deepEqual(useStudio.getState().selectAssetAliases, []);
+  store.undo();
+  assert.deepEqual(useStudio.getState().selectAssetAliases, ['hero']);
+  store.redo();
+  assert.deepEqual(useStudio.getState().selectAssetAliases, []);
 });
 
 test('new command clears redo stack', () => {

--- a/packages/studio/tests/undo-redo.test.ts
+++ b/packages/studio/tests/undo-redo.test.ts
@@ -1,0 +1,54 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+mock.method(global, 'setTimeout', () => 0 as any);
+mock.method(global, 'clearTimeout', () => {});
+
+const { useStudio, defaultProject } = await import('../src/state/useStudio.js');
+
+function reset() {
+  useStudio.setState({
+    project: structuredClone(defaultProject),
+    activeTab: 'Layout',
+    dirty: { layout: false, data: false, assets: false },
+    canvas: { width: 1280, height: 720 },
+  });
+}
+
+test('undo/redo restores deleted asset', () => {
+  reset();
+  const store = useStudio.getState();
+  store.setAssets([{ alias: 'hero', name: 'Hero', src: '' }]);
+  assert.equal(useStudio.getState().project.assets.length, 1);
+  store.deleteAsset('hero');
+  assert.equal(useStudio.getState().project.assets.length, 0);
+  store.undo();
+  assert.equal(useStudio.getState().project.assets.length, 1);
+  store.redo();
+  assert.equal(useStudio.getState().project.assets.length, 0);
+});
+
+test('new command clears redo stack', () => {
+  reset();
+  const store = useStudio.getState();
+  store.setAssets([{ alias: 'a1', name: '', src: '' }]);
+  store.setAssets([{ alias: 'a2', name: '', src: '' }]);
+  store.undo();
+  assert.equal(useStudio.getState().project.assets[0].alias, 'a1');
+  store.setAssets([{ alias: 'a3', name: '', src: '' }]);
+  store.redo();
+  assert.equal(useStudio.getState().project.assets[0].alias, 'a3');
+});
+
+test('history capped at 10 commands', () => {
+  reset();
+  const store = useStudio.getState();
+  for (let i = 1; i <= 11; i++) {
+    store.setAssets([{ alias: `a${i}`, name: '', src: '' }]);
+  }
+  for (let i = 0; i < 11; i++) {
+    store.undo();
+  }
+  const assets = useStudio.getState().project.assets;
+  assert.equal(assets.length, 1);
+  assert.equal(assets[0].alias, 'a1');
+});

--- a/packages/studio/tsconfig.test.json
+++ b/packages/studio/tsconfig.test.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "types": ["node"],
+    "allowImportingTsExtensions": false,
+    "allowSyntheticDefaultImports": true,
+    "erasableSyntaxOnly": false,
+    "moduleResolution": "node",
+    "verbatimModuleSyntax": false
+  },
+  "include": ["tests", "src/state/**/*", "src/types/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.12
         version: 4.1.12
+      '@types/node':
+        specifier: ^24.3.0
+        version: 24.3.0
       '@types/react':
         specifier: ^19.1.6
         version: 19.1.12

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
 
   packages/studio:
     dependencies:
+      fast-json-patch:
+        specifier: ^3.1.1
+        version: 3.1.1
       idb-keyval:
         specifier: ^6.2.2
         version: 6.2.2
@@ -974,6 +977,9 @@ packages:
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  fast-json-patch@3.1.1:
+    resolution: {integrity: sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2031,6 +2037,8 @@ snapshots:
   escalade@3.2.0: {}
 
   eventemitter3@4.0.7: {}
+
+  fast-json-patch@3.1.1: {}
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:


### PR DESCRIPTION
## Summary
- add undo/redo history in studio store for asset operations
- bind Ctrl+Z / Ctrl+Shift+Z to undo/redo while respecting code editor focus

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b597afbff4832ab8ed34e2b3c5481f