### PR TITLE
feat(studio): add scene tree panel

### DIFF
--- a/packages/studio/src/ui/panels/SceneTreePanel.tsx
+++ b/packages/studio/src/ui/panels/SceneTreePanel.tsx
@@ -5,19 +5,35 @@ import { useStudio } from "../../state/useStudio";
 // Tags that should not appear in the scene tree.
 const HIDDEN_TAGS = new Set(["Resources", "Template"]);
 
+function visibleChildren(el: Element): Element[] {
+  return Array.from(el.children).filter(
+    (c) => !HIDDEN_TAGS.has(c.tagName) && !c.tagName.includes("."),
+  );
+}
+
 function buildTree(el: Element, path: string): TreeItem {
   return {
     id: path,
-    name: el.tagName,
+    name: el.getAttribute("name") || el.tagName,
     type: "view",
-    children: Array.from(el.children)
-      .filter((c) => !HIDDEN_TAGS.has(c.tagName) && !c.tagName.includes("."))
-      .map((c, i) => buildTree(c, `${path}.${i}`)),
+    children: visibleChildren(el).map((c, i) => buildTree(c, `${path}.${i}`)),
   };
 }
 
+function findByPath(el: Element, path: string): Element | null {
+  const parts = path.split(".").slice(1);
+  let curr: Element | undefined = el;
+  for (const p of parts) {
+    if (!curr) return null;
+    const idx = Number(p);
+    const kids = visibleChildren(curr);
+    curr = kids[idx];
+  }
+  return curr ?? null;
+}
+
 export function SceneTreePanel() {
-  const { project } = useStudio();
+  const { project, setLayout } = useStudio();
   const [root, setRoot] = useState<TreeItem | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set(["0"]));
   const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -30,7 +46,7 @@ export function SceneTreePanel() {
     const el = dom.documentElement;
     if (el && el.nodeName !== "parsererror") {
       setRoot(buildTree(el, "0"));
-      setExpanded(new Set(["0"]));
+      setExpanded((prev) => (prev.size ? new Set(prev) : new Set(["0"])));
     } else {
       setRoot(null);
     }
@@ -63,6 +79,19 @@ export function SceneTreePanel() {
           })
         }
         onSelect={setSelected}
+        onRename={(id, nextName) => {
+          const dom = new DOMParser().parseFromString(
+            project.layout,
+            "application/xml",
+          );
+          const rootEl = dom.documentElement;
+          if (!rootEl || rootEl.nodeName === "parsererror") return;
+          const target = findByPath(rootEl, id);
+          if (!target) return;
+          target.setAttribute("name", nextName);
+          const xml = new XMLSerializer().serializeToString(dom);
+          setLayout(xml);
+        }}
       />
     </div>
   );

--- a/packages/studio/src/ui/panels/SceneTreePanel.tsx
+++ b/packages/studio/src/ui/panels/SceneTreePanel.tsx
@@ -2,14 +2,17 @@ import React, { useEffect, useState } from "react";
 import Tree, { type TreeItem } from "../tree/Tree";
 import { useStudio } from "../../state/useStudio";
 
+// Tags that should not appear in the scene tree.
+const HIDDEN_TAGS = new Set(["Resources", "Template"]);
+
 function buildTree(el: Element, path: string): TreeItem {
   return {
     id: path,
     name: el.tagName,
     type: "view",
-    children: Array.from(el.children).map((c, i) =>
-      buildTree(c, `${path}.${i}`),
-    ),
+    children: Array.from(el.children)
+      .filter((c) => !HIDDEN_TAGS.has(c.tagName) && !c.tagName.includes("."))
+      .map((c, i) => buildTree(c, `${path}.${i}`)),
   };
 }
 

--- a/packages/studio/src/ui/panels/SceneTreePanel.tsx
+++ b/packages/studio/src/ui/panels/SceneTreePanel.tsx
@@ -1,16 +1,67 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import Tree, { type TreeItem } from "../tree/Tree";
+import { useStudio } from "../../state/useStudio";
+
+function buildTree(el: Element, path: string): TreeItem {
+  return {
+    id: path,
+    name: el.tagName,
+    type: "view",
+    children: Array.from(el.children).map((c, i) =>
+      buildTree(c, `${path}.${i}`),
+    ),
+  };
+}
 
 export function SceneTreePanel() {
+  const { project } = useStudio();
+  const [root, setRoot] = useState<TreeItem | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set(["0"]));
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    const dom = new DOMParser().parseFromString(
+      project.layout,
+      "application/xml",
+    );
+    const el = dom.documentElement;
+    if (el && el.nodeName !== "parsererror") {
+      setRoot(buildTree(el, "0"));
+      setExpanded(new Set(["0"]));
+    } else {
+      setRoot(null);
+    }
+  }, [project.layout]);
+
+  if (!root)
+    return (
+      <div className="p-2 text-sm">
+        <div className="px-2 py-1 text-neutral-400 uppercase text-xs tracking-wide">
+          Scene
+        </div>
+        <div className="px-2 py-1 text-neutral-500">Invalid layout</div>
+      </div>
+    );
+
   return (
     <div className="p-2 text-sm">
-      <div className="px-2 py-1 text-neutral-400 uppercase text-xs tracking-wide">Scene</div>
-      <ul className="px-2 py-1 space-y-1">
-        {["Root","Canvas","Header","Sidebar","Content"].map((n,i)=>(
-          <li key={i} className="px-2 py-1 rounded hover:bg-neutral-800/50 cursor-default">
-            {n}
-          </li>
-        ))}
-      </ul>
+      <div className="px-2 py-1 text-neutral-400 uppercase text-xs tracking-wide">
+        Scene
+      </div>
+      <Tree
+        items={[root]}
+        expanded={expanded}
+        selected={selected}
+        onToggle={(id) =>
+          setExpanded((prev) => {
+            const next = new Set(prev);
+            next.has(id) ? next.delete(id) : next.add(id);
+            return next;
+          })
+        }
+        onSelect={setSelected}
+      />
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- add dynamic SceneTreePanel to Layout tab
- parse project layout XML into interactive tree view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e698c9dc832a9b32ac04d5989442