### PR TITLE
feat(studio): add basic schema editor

### DIFF
--- a/packages/studio/src/types/schema.ts
+++ b/packages/studio/src/types/schema.ts
@@ -1,0 +1,5 @@
+export type SchemaField = {
+  key: string;
+  type: string;
+  default?: string;
+};

--- a/packages/studio/src/ui/SchemaEditor.tsx
+++ b/packages/studio/src/ui/SchemaEditor.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { Plus, Trash2 } from 'lucide-react';
+import type { SchemaField } from '../types/schema.js';
+
+export default function SchemaEditor({
+  fields,
+  onChange,
+}: {
+  fields: SchemaField[];
+  onChange: (fields: SchemaField[]) => void;
+}) {
+  const handleChange = (
+    idx: number,
+    key: keyof SchemaField,
+    value: string,
+  ) => {
+    const next = fields.map((f, i) => (i === idx ? { ...f, [key]: value } : f));
+    onChange(next);
+  };
+
+  const addRow = () => {
+    onChange([...fields, { key: '', type: '', default: '' }]);
+  };
+
+  const removeRow = (idx: number) => {
+    const next = fields.filter((_, i) => i !== idx);
+    onChange(next);
+  };
+
+  return (
+    <table className="w-full text-sm border-collapse">
+      <thead>
+        <tr className="text-left border-b border-neutral-700">
+          <th className="px-2 py-1">Key</th>
+          <th className="px-2 py-1">Type</th>
+          <th className="px-2 py-1">Default</th>
+        </tr>
+      </thead>
+      <tbody>
+        {fields.map((f, idx) => (
+          <tr key={idx} className="border-b border-neutral-800">
+            <td className="px-2 py-1">
+              <input
+                className="w-full bg-transparent outline-none"
+                value={f.key}
+                onChange={(e) => handleChange(idx, 'key', e.target.value)}
+              />
+            </td>
+            <td className="px-2 py-1">
+              <input
+                className="w-full bg-transparent outline-none"
+                value={f.type}
+                onChange={(e) => handleChange(idx, 'type', e.target.value)}
+              />
+            </td>
+            <td className="px-2 py-1">
+              <div className="flex items-center gap-1">
+                <input
+                  className="flex-1 bg-transparent outline-none"
+                  value={f.default ?? ''}
+                  onChange={(e) => handleChange(idx, 'default', e.target.value)}
+                />
+                <button
+                  className="p-1 rounded hover:bg-neutral-700"
+                  onClick={() => removeRow(idx)}
+                  title="Delete field"
+                >
+                  <Trash2 size={14} />
+                </button>
+              </div>
+            </td>
+          </tr>
+        ))}
+        <tr>
+          <td colSpan={3} className="text-center py-2">
+            <button
+              className="inline-flex items-center gap-1 px-2 py-1 rounded bg-neutral-700 hover:bg-neutral-600"
+              onClick={addRow}
+            >
+              <Plus size={14} /> Add
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  );
+}

--- a/packages/studio/src/ui/panels/DataModelsPanel.tsx
+++ b/packages/studio/src/ui/panels/DataModelsPanel.tsx
@@ -1,16 +1,70 @@
-import React from "react";
+import React, { useEffect, useMemo, useState } from 'react';
+import { Plus } from 'lucide-react';
+import Tree, { type TreeItem } from '../tree/Tree';
+import { useStudio } from '../../state/useStudio';
+
+function buildRoot(data: Record<string, any>): TreeItem {
+  return {
+    id: 'schema-root',
+    name: 'Schemas',
+    type: 'folder',
+    children: Object.keys(data).map((name) => ({
+      id: `schema:${name}`,
+      name,
+      type: 'schema',
+      children: [],
+    })),
+  };
+}
 
 export function DataModelsPanel() {
+  const { project, addSchema, selectedSchema, setSelectedSchema } = useStudio();
+  const [root, setRoot] = useState<TreeItem>(() => buildRoot(project.data));
+  const [expanded, setExpanded] = useState<Set<string>>(new Set(['schema-root']));
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    setRoot(buildRoot(project.data));
+  }, [project.data]);
+
+  useEffect(() => {
+    if (selectedSchema) setSelected(new Set([`schema:${selectedSchema}`]));
+    else setSelected(new Set());
+  }, [selectedSchema]);
+
+  const visible = useMemo(() => [root], [root]);
+
   return (
-    <div className="p-2 text-sm">
-      <div className="px-2 py-1 text-neutral-400 uppercase text-xs tracking-wide">Models</div>
-      <ul className="px-2 py-1 space-y-1">
-        {["User","Task","Project"].map((n,i)=>(
-          <li key={i} className="px-2 py-1 rounded hover:bg-neutral-800/50 cursor-default">
-            {n}
-          </li>
-        ))}
-      </ul>
+    <div className="h-full overflow-auto p-2 text-sm">
+      <div className="px-2 py-1 text-neutral-400 uppercase text-xs tracking-wide flex items-center justify-between">
+        <span>Schemas</span>
+        <button
+          className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+          onClick={addSchema}
+          title="Add schema"
+        >
+          <Plus size={14} />
+        </button>
+      </div>
+      <Tree
+        items={visible}
+        expanded={expanded}
+        selected={selected}
+        onToggle={(id) =>
+          setExpanded((prev) => {
+            const next = new Set(prev);
+            next.has(id) ? next.delete(id) : next.add(id);
+            return next;
+          })
+        }
+        onSelect={(next) => {
+          setSelected(next);
+          const first = Array.from(next)[0];
+          if (first && first.startsWith('schema:'))
+            setSelectedSchema(first.slice('schema:'.length));
+          else setSelectedSchema(null);
+        }}
+      />
     </div>
   );
 }

--- a/packages/studio/src/ui/tabs/DataTab.tsx
+++ b/packages/studio/src/ui/tabs/DataTab.tsx
@@ -1,14 +1,33 @@
 import React from "react";
-import {useStudio} from "../../state/useStudio.ts";
+import { useStudio } from "../../state/useStudio.ts";
 import NoxiEditor from "../NoxiEditor.tsx";
+import SchemaEditor from "../SchemaEditor.tsx";
+import type { SchemaField } from "../../types/schema.js";
 
 export function DataTab() {
-  const { project, setData } = useStudio();
+  const { project, setData, selectedSchema, setSchemaFields } = useStudio();
+  const schema = selectedSchema
+    ? (project.data[selectedSchema] as SchemaField[] | undefined)
+    : undefined;
+  if (selectedSchema && Array.isArray(schema)) {
+    return (
+      <div className="p-2 overflow-auto h-full">
+        <SchemaEditor
+          fields={schema}
+          onChange={(f) => setSchemaFields(selectedSchema, f)}
+        />
+      </div>
+    );
+  }
   return (
     <NoxiEditor
       value={JSON.stringify(project.data, null, 2)}
       onChange={(txt) => {
-        try { setData(JSON.parse(txt)); } catch {/* валидацию можно добавить */}
+        try {
+          setData(JSON.parse(txt));
+        } catch {
+          /* валидацию можно добавить */
+        }
       }}
       language="json"
     />

--- a/packages/studio/src/ui/tree/Tree.tsx
+++ b/packages/studio/src/ui/tree/Tree.tsx
@@ -9,10 +9,19 @@ import {
   Database,
   Edit2,
   Trash2,
+  Braces,
+  Table as TableIcon,
 } from 'lucide-react'
 
 /** Типы узлов */
-export type TreeItemType = 'folder' | 'view' | 'component' | 'image' | 'data'
+export type TreeItemType =
+  | 'folder'
+  | 'view'
+  | 'component'
+  | 'image'
+  | 'data'
+  | 'schema'
+  | 'dataset'
 
 export type TreeItem = {
   id: string
@@ -39,6 +48,10 @@ export function iconFor(
       return <ImageIcon size={16} />
     case 'data':
       return <Database size={16} />
+    case 'schema':
+      return <Braces size={16} />
+    case 'dataset':
+      return <TableIcon size={16} />
     default:
       return <Layout size={16} />
   }


### PR DESCRIPTION
## Summary
- extend tree to support schema and dataset icons
- add schema management to studio state
- list schemas in sidebar with add button
- render schema editor table when a schema is selected

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e80daed8832aa982cac17152845e