### PR TITLE
feat(studio): add scene tree panel

### DIFF
--- a/packages/studio/src/ui/panels/SceneTreePanel.tsx
+++ b/packages/studio/src/ui/panels/SceneTreePanel.tsx
@@ -1,16 +1,128 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import Tree, { type TreeItem } from "../tree/Tree";
+import { useStudio } from "../../state/useStudio";
+import {
+  Box,
+  Component,
+  Image as ImageIcon,
+  MousePointer,
+  Square,
+  Type as TextIcon,
+} from "lucide-react";
+
+// Tags that should not appear in the scene tree.
+const HIDDEN_TAGS = new Set(["Resources", "Template"]);
+
+function visibleChildren(el: Element): Element[] {
+  return Array.from(el.children).filter(
+    (c) => !HIDDEN_TAGS.has(c.tagName) && !c.tagName.includes("."),
+  );
+}
+
+function buildTree(el: Element, path: string): TreeItem {
+  const nameAttr = el.getAttribute("name");
+  return {
+    id: path,
+    name: nameAttr || el.tagName,
+    type: "view",
+    tag: el.tagName,
+    children: visibleChildren(el).map((c, i) => buildTree(c, `${path}.${i}`)),
+  };
+}
+
+function iconForItem(item: TreeItem): React.ReactNode {
+  const tag = item.tag?.toLowerCase() || "";
+  if (tag.includes("image")) return <ImageIcon size={16} />;
+  if (tag.includes("text") || tag.includes("label")) return <TextIcon size={16} />;
+  if (tag.includes("button")) return <MousePointer size={16} />;
+  if (tag.includes("rect") || tag.includes("square")) return <Square size={16} />;
+  if (item.children && item.children.length) return <Box size={16} />;
+  return <Component size={16} />;
+}
+
+function findByPath(el: Element, path: string): Element | null {
+  const parts = path.split(".").slice(1);
+  let curr: Element | undefined = el;
+  for (const p of parts) {
+    if (!curr) return null;
+    const idx = Number(p);
+    const kids = visibleChildren(curr);
+    curr = kids[idx];
+  }
+  return curr ?? null;
+}
 
 export function SceneTreePanel() {
+  const { project, setLayout } = useStudio();
+  const [root, setRoot] = useState<TreeItem | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set(["0"]));
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    const dom = new DOMParser().parseFromString(
+      project.layout,
+      "application/xml",
+    );
+    const el = dom.documentElement;
+    if (el && el.nodeName !== "parsererror") {
+      setRoot(buildTree(el, "0"));
+      setExpanded((prev) => (prev.size ? new Set(prev) : new Set(["0"])));
+    } else {
+      setRoot(null);
+    }
+  }, [project.layout]);
+
+  if (!root)
+    return (
+      <div className="p-2 text-sm">
+        <div className="px-2 py-1 text-neutral-400 uppercase text-xs tracking-wide">
+          Scene
+        </div>
+        <div className="px-2 py-1 text-neutral-500">Invalid layout</div>
+      </div>
+    );
+
   return (
     <div className="p-2 text-sm">
-      <div className="px-2 py-1 text-neutral-400 uppercase text-xs tracking-wide">Scene</div>
-      <ul className="px-2 py-1 space-y-1">
-        {["Root","Canvas","Header","Sidebar","Content"].map((n,i)=>(
-          <li key={i} className="px-2 py-1 rounded hover:bg-neutral-800/50 cursor-default">
-            {n}
-          </li>
-        ))}
-      </ul>
+      <div className="px-2 py-1 text-neutral-400 uppercase text-xs tracking-wide">
+        Scene
+      </div>
+      <Tree
+        items={[root]}
+        expanded={expanded}
+        selected={selected}
+        renderIcon={(item) => iconForItem(item)}
+        renderLabel={(item) => (
+          <span className="truncate">
+            {item.name}
+            {item.tag && item.name !== item.tag && (
+              <span className="ml-1 text-xs text-neutral-400">({item.tag})</span>
+            )}
+          </span>
+        )}
+        onToggle={(id) =>
+          setExpanded((prev) => {
+            const next = new Set(prev);
+            next.has(id) ? next.delete(id) : next.add(id);
+            return next;
+          })
+        }
+        onSelect={setSelected}
+        onRename={(id, nextName) => {
+          const dom = new DOMParser().parseFromString(
+            project.layout,
+            "application/xml",
+          );
+          const rootEl = dom.documentElement;
+          if (!rootEl || rootEl.nodeName === "parsererror") return;
+          const target = findByPath(rootEl, id);
+          if (!target) return;
+          target.setAttribute("name", nextName);
+          const xml = new XMLSerializer().serializeToString(dom);
+          setLayout(xml);
+        }}
+      />
     </div>
   );
 }
+

--- a/packages/studio/src/ui/tree/Tree.tsx
+++ b/packages/studio/src/ui/tree/Tree.tsx
@@ -19,6 +19,8 @@ export type TreeItem = {
   name: string
   type: TreeItemType
   children?: TreeItem[]
+  /** Дополнительный тип/тег элемента */
+  tag?: string
 }
 
 export type DropPosition = 'inside' | 'before' | 'after'
@@ -61,6 +63,9 @@ export type TreeProps = {
 
   renderIcon?: (item: TreeItem, expanded: boolean) => React.ReactNode
 
+  /** Кастомный рендер подписи узла */
+  renderLabel?: (item: TreeItem) => React.ReactNode
+
   /** Кастомная политика dnd. По умолчанию: inside только в папку. */
   allowDrop?: (source: TreeItem, target: TreeItem, pos: DropPosition) => boolean
 }
@@ -85,6 +90,7 @@ export default function Tree({
   onRename,
   onDelete,
   renderIcon,
+  renderLabel,
   allowDrop,
 }: TreeProps) {
   const itemsMap = useMemo(() => collectMap(items), [items])
@@ -158,6 +164,7 @@ export default function Tree({
           onRename={onRename}
           onDelete={onDelete}
           renderIcon={renderIcon}
+          renderLabel={renderLabel}
           itemsMap={itemsMap}
           canDrop={canDrop}
           draggingIdsRef={draggingIdsRef}
@@ -179,6 +186,7 @@ function TreeNode({
   onRename,
   onDelete,
   renderIcon,
+  renderLabel,
   itemsMap,
   canDrop,
   draggingIdsRef,
@@ -196,6 +204,7 @@ function TreeNode({
   onRename?: (id: string, nextName: string) => void
   onDelete?: (id: string) => void
   renderIcon?: (item: TreeItem, expanded: boolean) => React.ReactNode
+  renderLabel?: (item: TreeItem) => React.ReactNode
   itemsMap: Map<string, TreeItem>
   canDrop: (source: TreeItem, target: TreeItem, pos: DropPosition) => boolean
   draggingIdsRef: React.MutableRefObject<string[] | null>
@@ -351,7 +360,11 @@ function TreeNode({
 
         {/* Имя / инпут */}
         {!editing ? (
-          <span className="truncate">{item.name}</span>
+          renderLabel ? (
+            renderLabel(item)
+          ) : (
+            <span className="truncate">{item.name}</span>
+          )
         ) : (
           <input
             ref={inputRef}
@@ -419,6 +432,7 @@ function TreeNode({
               onRename={onRename}
               onDelete={onDelete}
               renderIcon={renderIcon}
+              renderLabel={renderLabel}
               itemsMap={itemsMap}
               canDrop={canDrop}
               draggingIdsRef={draggingIdsRef}


### PR DESCRIPTION
## Summary
- add dynamic SceneTreePanel to Layout tab
- parse project layout XML into interactive tree view
- hide service tags so only containers and nodes show in tree
- display node `name` when available and persist renames back to layout XML
- show node-specific icons and append node type beside custom names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e698c9dc832a9b32ac04d5989442