### PR TITLE
feat(studio): add basic schema editor

### DIFF
--- a/packages/studio/src/state/useStudio.ts
+++ b/packages/studio/src/state/useStudio.ts
@@ -41,6 +41,7 @@ type StudioState = {
   setSelectedSchema: (name: string | null) => void;
   addSchema: () => void;
   setSchemaFields: (name: string, fields: SchemaField[]) => void;
+  renameSchema: (oldName: string, newName: string) => void;
 
   // tabs
   setTab: (t: Tab) => void;
@@ -239,6 +240,29 @@ export const useStudio = create<StudioState>((set, get) => {
         },
         dirty: { ...s.dirty, data: true },
       }));
+      scheduleSave();
+    },
+
+    renameSchema: (oldName, newName) => {
+      const trimmed = newName.trim();
+      if (!trimmed) return;
+      set((s) => {
+        const data = { ...(s.project.data ?? {}) };
+        if (!data[oldName]) return {};
+        const existing = new Set(Object.keys(data));
+        existing.delete(oldName);
+        let nextName = trimmed;
+        let i = 2;
+        while (existing.has(nextName)) nextName = `${trimmed} ${i++}`;
+        data[nextName] = data[oldName];
+        delete data[oldName];
+        return {
+          project: { ...s.project, data },
+          selectedSchema:
+            s.selectedSchema === oldName ? nextName : s.selectedSchema,
+          dirty: { ...s.dirty, data: true },
+        };
+      });
       scheduleSave();
     },
 

--- a/packages/studio/src/types/schema.ts
+++ b/packages/studio/src/types/schema.ts
@@ -1,0 +1,5 @@
+export type SchemaField = {
+  key: string;
+  type: string;
+  default?: string;
+};

--- a/packages/studio/src/ui/SchemaEditor.tsx
+++ b/packages/studio/src/ui/SchemaEditor.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { Plus, Trash2 } from 'lucide-react';
+import { Trash2 } from 'lucide-react';
 import type { SchemaField } from '../types/schema.js';
+
+const emptyField: SchemaField = { key: '', type: '', default: '' };
 
 export default function SchemaEditor({
   fields,
@@ -14,18 +16,20 @@ export default function SchemaEditor({
     key: keyof SchemaField,
     value: string,
   ) => {
-    const next = fields.map((f, i) => (i === idx ? { ...f, [key]: value } : f));
-    onChange(next);
-  };
-
-  const addRow = () => {
-    onChange([...fields, { key: '', type: '', default: '' }]);
+    const rows = [...fields, { ...emptyField }];
+    rows[idx] = { ...rows[idx], [key]: value };
+    const filtered = rows.filter(
+      (r) => r.key || r.type || (r.default ?? '') !== '',
+    );
+    onChange(filtered);
   };
 
   const removeRow = (idx: number) => {
     const next = fields.filter((_, i) => i !== idx);
     onChange(next);
   };
+
+  const rows = [...fields, { ...emptyField }];
 
   return (
     <table className="w-full text-sm border-collapse">
@@ -37,7 +41,7 @@ export default function SchemaEditor({
         </tr>
       </thead>
       <tbody>
-        {fields.map((f, idx) => (
+        {rows.map((f, idx) => (
           <tr key={idx} className="border-b border-neutral-800">
             <td className="px-2 py-1">
               <input
@@ -47,11 +51,18 @@ export default function SchemaEditor({
               />
             </td>
             <td className="px-2 py-1">
-              <input
+              <select
                 className="w-full bg-transparent outline-none"
                 value={f.type}
                 onChange={(e) => handleChange(idx, 'type', e.target.value)}
-              />
+              >
+                <option value=""></option>
+                <option value="Number">Number</option>
+                <option value="String">String</option>
+                <option value="Boolean">Boolean</option>
+                <option value="List">List</option>
+                <option value="Dictionary">Dictionary</option>
+              </select>
             </td>
             <td className="px-2 py-1">
               <div className="flex items-center gap-1">
@@ -60,27 +71,19 @@ export default function SchemaEditor({
                   value={f.default ?? ''}
                   onChange={(e) => handleChange(idx, 'default', e.target.value)}
                 />
-                <button
-                  className="p-1 rounded hover:bg-neutral-700"
-                  onClick={() => removeRow(idx)}
-                  title="Delete field"
-                >
-                  <Trash2 size={14} />
-                </button>
+                {idx < fields.length && (
+                  <button
+                    className="p-1 rounded hover:bg-neutral-700"
+                    onClick={() => removeRow(idx)}
+                    title="Delete field"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                )}
               </div>
             </td>
           </tr>
         ))}
-        <tr>
-          <td colSpan={3} className="text-center py-2">
-            <button
-              className="inline-flex items-center gap-1 px-2 py-1 rounded bg-neutral-700 hover:bg-neutral-600"
-              onClick={addRow}
-            >
-              <Plus size={14} /> Add
-            </button>
-          </td>
-        </tr>
       </tbody>
     </table>
   );

--- a/packages/studio/src/ui/SchemaEditor.tsx
+++ b/packages/studio/src/ui/SchemaEditor.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { Plus, Trash2 } from 'lucide-react';
+import type { SchemaField } from '../types/schema.js';
+
+export default function SchemaEditor({
+  fields,
+  onChange,
+}: {
+  fields: SchemaField[];
+  onChange: (fields: SchemaField[]) => void;
+}) {
+  const handleChange = (
+    idx: number,
+    key: keyof SchemaField,
+    value: string,
+  ) => {
+    const next = fields.map((f, i) => (i === idx ? { ...f, [key]: value } : f));
+    onChange(next);
+  };
+
+  const addRow = () => {
+    onChange([...fields, { key: '', type: '', default: '' }]);
+  };
+
+  const removeRow = (idx: number) => {
+    const next = fields.filter((_, i) => i !== idx);
+    onChange(next);
+  };
+
+  return (
+    <table className="w-full text-sm border-collapse">
+      <thead>
+        <tr className="text-left border-b border-neutral-700">
+          <th className="px-2 py-1">Key</th>
+          <th className="px-2 py-1">Type</th>
+          <th className="px-2 py-1">Default</th>
+        </tr>
+      </thead>
+      <tbody>
+        {fields.map((f, idx) => (
+          <tr key={idx} className="border-b border-neutral-800">
+            <td className="px-2 py-1">
+              <input
+                className="w-full bg-transparent outline-none"
+                value={f.key}
+                onChange={(e) => handleChange(idx, 'key', e.target.value)}
+              />
+            </td>
+            <td className="px-2 py-1">
+              <input
+                className="w-full bg-transparent outline-none"
+                value={f.type}
+                onChange={(e) => handleChange(idx, 'type', e.target.value)}
+              />
+            </td>
+            <td className="px-2 py-1">
+              <div className="flex items-center gap-1">
+                <input
+                  className="flex-1 bg-transparent outline-none"
+                  value={f.default ?? ''}
+                  onChange={(e) => handleChange(idx, 'default', e.target.value)}
+                />
+                <button
+                  className="p-1 rounded hover:bg-neutral-700"
+                  onClick={() => removeRow(idx)}
+                  title="Delete field"
+                >
+                  <Trash2 size={14} />
+                </button>
+              </div>
+            </td>
+          </tr>
+        ))}
+        <tr>
+          <td colSpan={3} className="text-center py-2">
+            <button
+              className="inline-flex items-center gap-1 px-2 py-1 rounded bg-neutral-700 hover:bg-neutral-600"
+              onClick={addRow}
+            >
+              <Plus size={14} /> Add
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  );
+}

--- a/packages/studio/src/ui/panels/DataModelsPanel.tsx
+++ b/packages/studio/src/ui/panels/DataModelsPanel.tsx
@@ -5,9 +5,9 @@ import { useStudio } from '../../state/useStudio';
 
 function buildRoot(data: Record<string, any>): TreeItem {
   return {
-    id: 'schema-root',
-    name: 'Schemas',
-    type: 'folder',
+    id: 'data-root',
+    name: 'Data',
+    type: 'data',
     children: Object.keys(data).map((name) => ({
       id: `schema:${name}`,
       name,
@@ -18,9 +18,9 @@ function buildRoot(data: Record<string, any>): TreeItem {
 }
 
 export function DataModelsPanel() {
-  const { project, addSchema, selectedSchema, setSelectedSchema } = useStudio();
+  const { project, addSchema, selectedSchema, setSelectedSchema, renameSchema } = useStudio();
   const [root, setRoot] = useState<TreeItem>(() => buildRoot(project.data));
-  const [expanded, setExpanded] = useState<Set<string>>(new Set(['schema-root']));
+  const [expanded, setExpanded] = useState<Set<string>>(new Set(['data-root']));
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
   useEffect(() => {
@@ -37,7 +37,7 @@ export function DataModelsPanel() {
   return (
     <div className="h-full overflow-auto p-2 text-sm">
       <div className="px-2 py-1 text-neutral-400 uppercase text-xs tracking-wide flex items-center justify-between">
-        <span>Schemas</span>
+        <span>Data</span>
         <button
           className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
           onClick={addSchema}
@@ -63,6 +63,10 @@ export function DataModelsPanel() {
           if (first && first.startsWith('schema:'))
             setSelectedSchema(first.slice('schema:'.length));
           else setSelectedSchema(null);
+        }}
+        onRename={(id, nextName) => {
+          if (id.startsWith('schema:'))
+            renameSchema(id.slice('schema:'.length), nextName);
         }}
       />
     </div>

--- a/packages/studio/src/ui/panels/DataModelsPanel.tsx
+++ b/packages/studio/src/ui/panels/DataModelsPanel.tsx
@@ -5,8 +5,8 @@ import { useStudio } from '../../state/useStudio';
 
 function buildRoot(data: Record<string, any>): TreeItem {
   return {
-    id: 'data-root',
-    name: 'Data',
+    id: 'models-root',
+    name: 'Models',
     type: 'data',
     children: Object.keys(data).map((name) => ({
       id: `schema:${name}`,
@@ -18,9 +18,9 @@ function buildRoot(data: Record<string, any>): TreeItem {
 }
 
 export function DataModelsPanel() {
-  const { project, addSchema, selectedSchema, setSelectedSchema, renameSchema } = useStudio();
+  const { project, addSchema, selectedSchema, setSelectedSchema, renameSchema, deleteSchema } = useStudio();
   const [root, setRoot] = useState<TreeItem>(() => buildRoot(project.data));
-  const [expanded, setExpanded] = useState<Set<string>>(new Set(['data-root']));
+  const [expanded, setExpanded] = useState<Set<string>>(new Set(['models-root']));
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
   useEffect(() => {
@@ -37,7 +37,7 @@ export function DataModelsPanel() {
   return (
     <div className="h-full overflow-auto p-2 text-sm">
       <div className="px-2 py-1 text-neutral-400 uppercase text-xs tracking-wide flex items-center justify-between">
-        <span>Data</span>
+        <span>Models</span>
         <button
           className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
           onClick={addSchema}
@@ -67,6 +67,10 @@ export function DataModelsPanel() {
         onRename={(id, nextName) => {
           if (id.startsWith('schema:'))
             renameSchema(id.slice('schema:'.length), nextName);
+        }}
+        onDelete={(id) => {
+          if (id.startsWith('schema:'))
+            deleteSchema(id.slice('schema:'.length));
         }}
       />
     </div>

--- a/packages/studio/src/ui/panels/DataModelsPanel.tsx
+++ b/packages/studio/src/ui/panels/DataModelsPanel.tsx
@@ -1,16 +1,70 @@
-import React from "react";
+import React, { useEffect, useMemo, useState } from 'react';
+import { Plus } from 'lucide-react';
+import Tree, { type TreeItem } from '../tree/Tree';
+import { useStudio } from '../../state/useStudio';
+
+function buildRoot(data: Record<string, any>): TreeItem {
+  return {
+    id: 'schema-root',
+    name: 'Schemas',
+    type: 'folder',
+    children: Object.keys(data).map((name) => ({
+      id: `schema:${name}`,
+      name,
+      type: 'schema',
+      children: [],
+    })),
+  };
+}
 
 export function DataModelsPanel() {
+  const { project, addSchema, selectedSchema, setSelectedSchema } = useStudio();
+  const [root, setRoot] = useState<TreeItem>(() => buildRoot(project.data));
+  const [expanded, setExpanded] = useState<Set<string>>(new Set(['schema-root']));
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    setRoot(buildRoot(project.data));
+  }, [project.data]);
+
+  useEffect(() => {
+    if (selectedSchema) setSelected(new Set([`schema:${selectedSchema}`]));
+    else setSelected(new Set());
+  }, [selectedSchema]);
+
+  const visible = useMemo(() => [root], [root]);
+
   return (
-    <div className="p-2 text-sm">
-      <div className="px-2 py-1 text-neutral-400 uppercase text-xs tracking-wide">Models</div>
-      <ul className="px-2 py-1 space-y-1">
-        {["User","Task","Project"].map((n,i)=>(
-          <li key={i} className="px-2 py-1 rounded hover:bg-neutral-800/50 cursor-default">
-            {n}
-          </li>
-        ))}
-      </ul>
+    <div className="h-full overflow-auto p-2 text-sm">
+      <div className="px-2 py-1 text-neutral-400 uppercase text-xs tracking-wide flex items-center justify-between">
+        <span>Schemas</span>
+        <button
+          className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+          onClick={addSchema}
+          title="Add schema"
+        >
+          <Plus size={14} />
+        </button>
+      </div>
+      <Tree
+        items={visible}
+        expanded={expanded}
+        selected={selected}
+        onToggle={(id) =>
+          setExpanded((prev) => {
+            const next = new Set(prev);
+            next.has(id) ? next.delete(id) : next.add(id);
+            return next;
+          })
+        }
+        onSelect={(next) => {
+          setSelected(next);
+          const first = Array.from(next)[0];
+          if (first && first.startsWith('schema:'))
+            setSelectedSchema(first.slice('schema:'.length));
+          else setSelectedSchema(null);
+        }}
+      />
     </div>
   );
 }

--- a/packages/studio/src/ui/tabs/DataTab.tsx
+++ b/packages/studio/src/ui/tabs/DataTab.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Plus } from "lucide-react";
+import { Plus, Braces, Table } from "lucide-react";
 import { useStudio } from "../../state/useStudio.ts";
 import SchemaEditor from "../SchemaEditor.tsx";
 import NoxiEditor from "../NoxiEditor.tsx";
@@ -45,29 +45,55 @@ export function DataTab() {
       }
     };
 
+    const handleFieldsChange = (f: SchemaField[]) => {
+      const filtered = f.filter(
+        (r) => r.key || r.type || (r.default ?? "") !== "",
+      );
+      setSchemaFields(selectedSchema, filtered);
+    };
+
     return (
-      <div className="p-2 h-full flex flex-col">
-        <div className="flex justify-end mb-2">
-          <button
-            className="px-2 py-1 text-sm rounded bg-neutral-700 hover:bg-neutral-600"
-            onClick={() => setMode(mode === "table" ? "json" : "table")}
-          >
-            {mode === "table" ? "JSON" : "Table"} view
-          </button>
+      <div className="h-full flex flex-col">
+        <div className="px-3 py-2 border-b border-[rgb(var(--cu-border))] bg-[rgb(var(--cu-grey200))] flex items-center justify-end shadow-sm">
+          <div className="flex border border-[rgb(var(--cu-border))] rounded-sm overflow-hidden">
+            <button
+              className={[
+                "h-7 w-7 grid place-items-center",
+                mode === "table"
+                  ? "bg-[#2C1A75] text-[#A89FFF]"
+                  : "bg-[rgb(var(--cu-topbar))] hover:bg-[rgb(var(--cu-grey200))] text-neutral-300",
+              ].join(" ")}
+              onClick={() => setMode("table")}
+              title="Table view"
+            >
+              <Table size={14} />
+            </button>
+            <button
+              className={[
+                "h-7 w-7 grid place-items-center",
+                mode === "json"
+                  ? "bg-[#2C1A75] text-[#A89FFF]"
+                  : "bg-[rgb(var(--cu-topbar))] hover:bg-[rgb(var(--cu-grey200))] text-neutral-300",
+              ].join(" ")}
+              onClick={() => setMode("json")}
+              title="JSON view"
+            >
+              <Braces size={14} />
+            </button>
+          </div>
         </div>
-        {mode === "table" ? (
-          <SchemaEditor
-            fields={schema}
-            onChange={(f) => setSchemaFields(selectedSchema, f)}
-          />
-        ) : (
-          <NoxiEditor
-            className="flex-1"
-            value={json}
-            onChange={handleJsonChange}
-            language="json"
-          />
-        )}
+        <div className="flex-1 overflow-auto p-2">
+          {mode === "table" ? (
+            <SchemaEditor fields={schema} onChange={handleFieldsChange} />
+          ) : (
+            <NoxiEditor
+              className="flex-1"
+              value={json}
+              onChange={handleJsonChange}
+              language="json"
+            />
+          )}
+        </div>
       </div>
     );
   }

--- a/packages/studio/src/ui/tabs/DataTab.tsx
+++ b/packages/studio/src/ui/tabs/DataTab.tsx
@@ -1,17 +1,76 @@
-import React from "react";
-import {useStudio} from "../../state/useStudio.ts";
+import React, { useEffect, useState } from "react";
+import { Plus } from "lucide-react";
+import { useStudio } from "../../state/useStudio.ts";
+import SchemaEditor from "../SchemaEditor.tsx";
 import NoxiEditor from "../NoxiEditor.tsx";
+import type { SchemaField } from "../../types/schema.js";
 
 export function DataTab() {
-  const { project, setData } = useStudio();
-  return (
-    <NoxiEditor
-      value={JSON.stringify(project.data, null, 2)}
-      onChange={(txt) => {
-        try { setData(JSON.parse(txt)); } catch {/* валидацию можно добавить */}
-      }}
-      language="json"
-    />
-  );
+  const { project, selectedSchema, addSchema, setSchemaFields } = useStudio();
+  const data = project.data;
+  const [mode, setMode] = useState<"table" | "json">("table");
+  const [json, setJson] = useState("");
+
+  useEffect(() => {
+    if (selectedSchema && Array.isArray(data[selectedSchema])) {
+      setJson(JSON.stringify(data[selectedSchema], null, 2));
+    }
+  }, [selectedSchema, data]);
+
+  if (Object.keys(data).length === 0) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <button
+          className="inline-flex items-center gap-1 px-3 py-2 rounded bg-neutral-700 hover:bg-neutral-600"
+          onClick={addSchema}
+        >
+          <Plus size={14} /> Create schema
+        </button>
+      </div>
+    );
+  }
+
+  const schema = selectedSchema
+    ? (data[selectedSchema] as SchemaField[] | undefined)
+    : undefined;
+  if (selectedSchema && Array.isArray(schema)) {
+    const handleJsonChange = (v: string) => {
+      setJson(v);
+      try {
+        const parsed = JSON.parse(v);
+        if (Array.isArray(parsed))
+          setSchemaFields(selectedSchema, parsed as SchemaField[]);
+      } catch {
+        // ignore parse errors
+      }
+    };
+
+    return (
+      <div className="p-2 h-full flex flex-col">
+        <div className="flex justify-end mb-2">
+          <button
+            className="px-2 py-1 text-sm rounded bg-neutral-700 hover:bg-neutral-600"
+            onClick={() => setMode(mode === "table" ? "json" : "table")}
+          >
+            {mode === "table" ? "JSON" : "Table"} view
+          </button>
+        </div>
+        {mode === "table" ? (
+          <SchemaEditor
+            fields={schema}
+            onChange={(f) => setSchemaFields(selectedSchema, f)}
+          />
+        ) : (
+          <NoxiEditor
+            className="flex-1"
+            value={json}
+            onChange={handleJsonChange}
+            language="json"
+          />
+        )}
+      </div>
+    );
+  }
+  return null;
 }
 

--- a/packages/studio/src/ui/tree/Tree.tsx
+++ b/packages/studio/src/ui/tree/Tree.tsx
@@ -9,10 +9,19 @@ import {
   Database,
   Edit2,
   Trash2,
+  Braces,
+  Table as TableIcon,
 } from 'lucide-react'
 
 /** Типы узлов */
-export type TreeItemType = 'folder' | 'view' | 'component' | 'image' | 'data'
+export type TreeItemType =
+  | 'folder'
+  | 'view'
+  | 'component'
+  | 'image'
+  | 'data'
+  | 'schema'
+  | 'dataset'
 
 export type TreeItem = {
   id: string
@@ -39,6 +48,10 @@ export function iconFor(
       return <ImageIcon size={16} />
     case 'data':
       return <Database size={16} />
+    case 'schema':
+      return <Braces size={16} />
+    case 'dataset':
+      return <TableIcon size={16} />
     default:
       return <Layout size={16} />
   }


### PR DESCRIPTION
## Summary
- extend tree to support schema and dataset icons
- add schema management to studio state
- list schemas in sidebar with add button
- render schema editor table when a schema is selected
- show "Create schema" button when no schemas exist
- allow switching between table and JSON schema editors

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e80daed8832aa982cac17152845e