### PR TITLE
feat(studio): allow resizing split panes

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -1,23 +1,23 @@
-import React, { useEffect } from "react";
-import { useStudio } from "./state/useStudio";
-import { AppShell } from "./ui/AppShell";
-import { Sidebar } from "./ui/Sidebar";
-import { TopbarActions } from "./ui/TopbarActions";
-import { TopbarTitle } from "./ui/TopbarTitle";
-import { LayoutTab } from "./ui/tabs/LayoutTab";
-import { DataTab } from "./ui/tabs/DataTab";
-import { AssetsTab } from "./ui/tabs/AssetsTab";
-import { Renderer } from "./Renderer";
+import React, { useEffect } from 'react'
+import { useStudio } from './state/useStudio'
+import { AppShell } from './ui/AppShell'
+import { Sidebar } from './ui/Sidebar'
+import { TopbarActions } from './ui/TopbarActions'
+import { TopbarTitle } from './ui/TopbarTitle'
+import { LayoutTab } from './ui/tabs/LayoutTab'
+import { DataTab } from './ui/tabs/DataTab'
+import { AssetsTab } from './ui/tabs/AssetsTab'
+import { Renderer } from './Renderer'
+import { SplitPane } from './ui/SplitPane'
 
-type Tab = "Layout" | "Data" | "ViewModels" | "Assets";
+type Tab = 'Layout' | 'Data' | 'ViewModels' | 'Assets'
 
 export default function App() {
-  const { hydrate } = useStudio();
+  const { hydrate } = useStudio()
 
   useEffect(() => {
-    hydrate(); // восстановить проект и ассеты из IndexedDB
-  }, [hydrate]);
-
+    hydrate() // восстановить проект и ассеты из IndexedDB
+  }, [hydrate])
 
   const {
     project,
@@ -27,28 +27,35 @@ export default function App() {
     renameProject, // ← добавь в стор, если ещё нет
     undo,
     redo,
-  } = useStudio() as any;
+  } = useStudio() as any
 
   useEffect(() => {
     const isTextInput = (el: any) =>
       el.tagName === 'INPUT' ||
       el.tagName === 'TEXTAREA' ||
       el.isContentEditable ||
-      el.closest?.('.monaco-editor');
+      el.closest?.('.monaco-editor')
     const onKey = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'z') {
-        if (isTextInput(e.target as HTMLElement)) return;
-        e.preventDefault();
-        e.shiftKey ? redo() : undo();
+        if (isTextInput(e.target as HTMLElement)) return
+        e.preventDefault()
+        e.shiftKey ? redo() : undo()
       }
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [undo, redo]);
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [undo, redo])
 
-  const onImport = async () => { /* твой код */ };
-  const onExport = () => { /* твой код */ };
-  const onRun = () => console.log("run");
+  const onImport = async () => {
+    /* твой код */
+  }
+  const onExport = () => {
+    /* твой код */
+  }
+  const onRun = () => console.log('run')
+
+  const defaultEditorWidth =
+    typeof window !== 'undefined' ? window.innerWidth / 2 : 600
 
   return (
     <AppShell
@@ -77,23 +84,30 @@ export default function App() {
         </div>
       }
     >
-      <div className="grid grid-cols-2 h-full">
-        {/* левая панель с редакторами */}
-        <div className="min-h-0 border-r border-neutral-800 overflow-hidden">
-          {/* табы */}
-          {activeTab === "Layout" && <LayoutTab/>}
-          {activeTab === "Data" && <DataTab/>}
-          {activeTab === "ViewModels" && <div className="p-4">ViewModels editor WIP</div>}
-          {activeTab === "Assets" && <AssetsTab/>}
-        </div>
-
-        {/* правая панель с CanvasStage */}
-        <div className="min-h-0 overflow-hidden">
-          <div className="h-full relative">
-            <Renderer/>
+      <SplitPane
+        storageKey="App.mainSplit"
+        defaultLeftWidth={defaultEditorWidth}
+        className="h-full"
+        left={
+          <div className="min-h-0 overflow-hidden">
+            {/* левая панель с редакторами */}
+            {activeTab === 'Layout' && <LayoutTab />}
+            {activeTab === 'Data' && <DataTab />}
+            {activeTab === 'ViewModels' && (
+              <div className="p-4">ViewModels editor WIP</div>
+            )}
+            {activeTab === 'Assets' && <AssetsTab />}
           </div>
-        </div>
-      </div>
+        }
+        right={
+          <div className="min-h-0 overflow-hidden">
+            {/* правая панель с CanvasStage */}
+            <div className="h-full relative">
+              <Renderer />
+            </div>
+          </div>
+        }
+      />
     </AppShell>
-  );
+  )
 }

--- a/packages/studio/src/ui/AppShell.tsx
+++ b/packages/studio/src/ui/AppShell.tsx
@@ -16,7 +16,7 @@ export function AppShell({
       defaultLeftWidth={260}
       className="w-screen h-screen bg-[rgb(var(--cu-grey100))] text-neutral-200"
       left={
-        <aside className="flex flex-col bg-[rgb(var(--cu-grey200))]">
+        <aside className="flex flex-col bg-[rgb(var(--cu-grey200))] border-r-[1px] border-[rgb(var(--cu-border))]">
           {sidebar}
         </aside>
       }

--- a/packages/studio/src/ui/AppShell.tsx
+++ b/packages/studio/src/ui/AppShell.tsx
@@ -1,26 +1,33 @@
-import React from "react";
+import React from 'react'
+import { SplitPane } from './SplitPane'
 
 export function AppShell({
-                           sidebar,
-                           topbar,
-                           children,
-                         }: {
-  sidebar: React.ReactNode;
-  topbar?: React.ReactNode; // оставим как есть — внутрь передадим уже готовый flex
-  children: React.ReactNode;
+  sidebar,
+  topbar,
+  children,
+}: {
+  sidebar: React.ReactNode
+  topbar?: React.ReactNode // оставим как есть — внутрь передадим уже готовый flex
+  children: React.ReactNode
 }) {
   return (
-    <div className="w-screen h-screen grid grid-cols-[260px_1fr] bg-[rgb(var(--cu-grey100))] text-neutral-200">
-      <aside className="flex flex-col bg-[rgb(var(--cu-grey200))] border-r-[1px] border-[rgb(var(--cu-border))]">
-        {sidebar}
-      </aside>
-
-      <main className="grid grid-rows-[48px_1fr] min-h-0">
-        <div className="h-12 px-3 flex items-center justify-between bg-[rgb(var(--cu-topbar))] border-b-[1px] border-[rgb(var(--cu-border))]">
-          {topbar}
-        </div>
-        <div className="min-h-0 overflow-hidden">{children}</div>
-      </main>
-    </div>
-  );
+    <SplitPane
+      storageKey="AppShell.sidebarWidth"
+      defaultLeftWidth={260}
+      className="w-screen h-screen bg-[rgb(var(--cu-grey100))] text-neutral-200"
+      left={
+        <aside className="flex flex-col bg-[rgb(var(--cu-grey200))]">
+          {sidebar}
+        </aside>
+      }
+      right={
+        <main className="grid grid-rows-[48px_1fr] min-h-0">
+          <div className="h-12 px-3 flex items-center justify-between bg-[rgb(var(--cu-topbar))] border-b-[1px] border-[rgb(var(--cu-border))]">
+            {topbar}
+          </div>
+          <div className="min-h-0 overflow-hidden">{children}</div>
+        </main>
+      }
+    />
+  )
 }

--- a/packages/studio/src/ui/SplitPane.tsx
+++ b/packages/studio/src/ui/SplitPane.tsx
@@ -57,16 +57,18 @@ export function SplitPane({
   }
 
   return (
-    <div
-      className={['grid', className].filter(Boolean).join(' ')}
-      style={{ gridTemplateColumns: `${leftWidth}px 4px 1fr` }}
-    >
-      <div className="min-h-0 overflow-hidden">{left}</div>
+    <div className={["flex", className].filter(Boolean).join(" ")}>      
       <div
-        className="cursor-col-resize bg-[rgb(var(--cu-border))]"
+        style={{ width: leftWidth }}
+        className="shrink-0 min-w-0 min-h-0 overflow-hidden"
+      >
+        {left}
+      </div>
+      <div
+        className="w-1 h-full cursor-col-resize bg-[rgb(var(--cu-border))]"
         onMouseDown={startDrag}
       />
-      <div className="min-h-0 overflow-hidden">{right}</div>
+      <div className="flex-1 min-w-0 min-h-0 overflow-hidden">{right}</div>
     </div>
   )
 }

--- a/packages/studio/src/ui/SplitPane.tsx
+++ b/packages/studio/src/ui/SplitPane.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+
+export type SplitPaneProps = {
+  left: React.ReactNode
+  right: React.ReactNode
+  /** Key used for localStorage persistence */
+  storageKey: string
+  /** Initial width in pixels for the left pane */
+  defaultLeftWidth?: number
+  /** Minimum width for the left pane */
+  minLeftWidth?: number
+  /** Additional className for container */
+  className?: string
+}
+
+export function SplitPane({
+  left,
+  right,
+  storageKey,
+  defaultLeftWidth = 260,
+  minLeftWidth = 150,
+  className,
+}: SplitPaneProps) {
+  const [leftWidth, setLeftWidth] = React.useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem(storageKey)
+      if (stored) return parseInt(stored, 10)
+      return defaultLeftWidth
+    }
+    return defaultLeftWidth
+  })
+
+  React.useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(storageKey, String(leftWidth))
+    }
+  }, [leftWidth, storageKey])
+
+  const startDrag = (e: React.MouseEvent) => {
+    e.preventDefault()
+    const startX = e.clientX
+    const startWidth = leftWidth
+
+    const onMove = (ev: MouseEvent) => {
+      const delta = ev.clientX - startX
+      const next = Math.max(minLeftWidth, startWidth + delta)
+      setLeftWidth(next)
+    }
+
+    const onUp = () => {
+      document.removeEventListener('mousemove', onMove)
+      document.removeEventListener('mouseup', onUp)
+    }
+
+    document.addEventListener('mousemove', onMove)
+    document.addEventListener('mouseup', onUp)
+  }
+
+  return (
+    <div
+      className={['grid', className].filter(Boolean).join(' ')}
+      style={{ gridTemplateColumns: `${leftWidth}px 4px 1fr` }}
+    >
+      <div className="min-h-0 overflow-hidden">{left}</div>
+      <div
+        className="cursor-col-resize bg-[rgb(var(--cu-border))]"
+        onMouseDown={startDrag}
+      />
+      <div className="min-h-0 overflow-hidden">{right}</div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add reusable `SplitPane` component that persists width in localStorage
- make sidebar and editor/canvas panes resizable using the new component

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b72525dea8832aa7c1c36ad662ced1