### PR TITLE
feat(studio): add split container

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -8,6 +8,8 @@ import { LayoutTab } from "./ui/tabs/LayoutTab";
 import { DataTab } from "./ui/tabs/DataTab";
 import { AssetsTab } from "./ui/tabs/AssetsTab";
 import { Renderer } from "./Renderer";
+import { SplitContainer } from "./ui/SplitContainer";
+import { SplitWindow } from "./ui/SplitWindow";
 
 type Tab = "Layout" | "Data" | "ViewModels" | "Assets";
 
@@ -77,23 +79,19 @@ export default function App() {
         </div>
       }
     >
-      <div className="grid grid-cols-2 h-full">
-        {/* левая панель с редакторами */}
-        <div className="min-h-0 border-r border-neutral-800 overflow-hidden">
-          {/* табы */}
+      <SplitContainer>
+        <SplitWindow>
           {activeTab === "Layout" && <LayoutTab/>}
           {activeTab === "Data" && <DataTab/>}
           {activeTab === "ViewModels" && <div className="p-4">ViewModels editor WIP</div>}
           {activeTab === "Assets" && <AssetsTab/>}
-        </div>
-
-        {/* правая панель с CanvasStage */}
-        <div className="min-h-0 overflow-hidden">
+        </SplitWindow>
+        <SplitWindow>
           <div className="h-full relative">
             <Renderer/>
           </div>
-        </div>
-      </div>
+        </SplitWindow>
+      </SplitContainer>
     </AppShell>
   );
 }

--- a/packages/studio/src/ui/SplitContainer.tsx
+++ b/packages/studio/src/ui/SplitContainer.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useRef, useState } from "react";
+
+export function SplitContainer({
+                               children,
+                             }: {
+  children: React.ReactElement[];
+}) {
+  const childArray = React.Children.toArray(children) as React.ReactElement[];
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const [sizes, setSizes] = useState<number[]>(() => {
+    if (typeof window !== "undefined") {
+      const saved = localStorage.getItem("split-sizes");
+      if (saved) {
+        try {
+          const parsed = JSON.parse(saved);
+          if (Array.isArray(parsed) && parsed.length === childArray.length) {
+            return parsed as number[];
+          }
+        } catch {
+        }
+      }
+    }
+    return childArray.map(() => 100 / childArray.length);
+  });
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("split-sizes", JSON.stringify(sizes));
+    }
+  }, [sizes]);
+
+  const startDrag = (index: number) => (e: React.MouseEvent) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startSizes = [...sizes];
+    const rect = containerRef.current?.getBoundingClientRect();
+    const width = rect?.width || 1;
+
+    const onMouseMove = (ev: MouseEvent) => {
+      const delta = ev.clientX - startX;
+      const deltaPercent = (delta / width) * 100;
+      const next = [...startSizes];
+      next[index] = Math.max(5, startSizes[index] + deltaPercent);
+      next[index + 1] = Math.max(5, startSizes[index + 1] - deltaPercent);
+      setSizes(next);
+    };
+
+    const onMouseUp = () => {
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("mouseup", onMouseUp);
+    };
+
+    window.addEventListener("mousemove", onMouseMove);
+    window.addEventListener("mouseup", onMouseUp);
+  };
+
+  return (
+    <div ref={containerRef} className="flex w-full h-full">
+      {childArray.map((child, i) => (
+        <React.Fragment key={i}>
+          <div style={{ width: `${sizes[i]}%` }} className="min-h-0">
+            {child}
+          </div>
+          {i < childArray.length - 1 && (
+            <div
+              className="w-1 h-full cursor-col-resize bg-neutral-800"
+              onMouseDown={startDrag(i)}
+            />
+          )}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+}

--- a/packages/studio/src/ui/SplitWindow.tsx
+++ b/packages/studio/src/ui/SplitWindow.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+export function SplitWindow({
+                             topbar,
+                             children,
+                           }: {
+  topbar?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col h-full">
+      {topbar && (
+        <div className="border-b border-neutral-800 px-2 py-1">
+          {topbar}
+        </div>
+      )}
+      <div className="flex-1 min-h-0 overflow-hidden">
+        {children}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add SplitContainer with drag-to-resize panels and persisted widths
- add SplitWindow with optional topbar slot
- switch App layout to use SplitContainer instead of fixed grid

## Testing
- `pnpm test` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68b730e8da4c832a9b8ce6be18046819