### PR TITLE
Refactor split layout with shared top bar and gutter

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -11,6 +11,7 @@ import { ViewModelsTab } from "./viewmodels/ViewModelsTab";
 import { Renderer } from "./layout/components/Renderer";
 import { SplitContainer } from "./ui/SplitContainer";
 import { SplitWindow } from "./ui/SplitWindow";
+import { CanvasToolbar } from "./layout/components/CanvasToolbar";
 
 type Tab = "Layout" | "Data" | "ViewModels" | "Assets";
 
@@ -30,6 +31,8 @@ export default function App() {
     renameProject, // ← добавь в стор, если ещё нет
     undo,
     redo,
+    setCanvasSize,
+    swapCanvasSize,
   } = useStudio() as any;
 
   useEffect(() => {
@@ -87,9 +90,18 @@ export default function App() {
           {activeTab === "ViewModels" && <ViewModelsTab />}
           {activeTab === "Assets" && <AssetsTab />}
         </SplitWindow>
-        <SplitWindow>
+        <SplitWindow
+          topbar={
+            <CanvasToolbar
+              width={project.screen?.width ?? 1280}
+              height={project.screen?.height ?? 720}
+              onCommitSize={(w, h) => setCanvasSize(w, h)}
+              onSwap={swapCanvasSize}
+            />
+          }
+        >
           <div className="h-full relative">
-            <Renderer/>
+            <Renderer />
           </div>
         </SplitWindow>
       </SplitContainer>

--- a/packages/studio/src/layout/components/CanvasStage.tsx
+++ b/packages/studio/src/layout/components/CanvasStage.tsx
@@ -1,6 +1,5 @@
-import React, { useRef, useState, useEffect } from "react";
+import React, { useRef } from "react";
 import { useStudio } from "../../state/useStudio";
-import { CanvasToolbar } from "./CanvasToolbar";
 import { useFitScale } from "../hooks/useFitScale";
 
 export default function CanvasStage({
@@ -10,28 +9,10 @@ export default function CanvasStage({
   children?: React.ReactNode;
   className?: string;
 }) {
-  const { project, setCanvasSize, swapCanvasSize } = useStudio();
+  const { project } = useStudio();
   const { width, height } = project.screen ?? { width: 1280, height: 720 };
 
-  // 1) реф тулбара и его динамическая высота
-  const toolbarRef = useRef<HTMLDivElement>(null);
-  const [toolbarH, setToolbarH] = useState(40); // дефолт 40px (h-10)
-
-  useEffect(() => {
-    const el = toolbarRef.current;
-    if (!el) return;
-    const update = () => setToolbarH(el.offsetHeight || 40);
-    update();
-    const ro = new ResizeObserver(update);
-    ro.observe(el);
-    window.addEventListener("resize", update);
-    return () => {
-      ro.disconnect();
-      window.removeEventListener("resize", update);
-    };
-  }, []);
-
-  // 2) safe-area: пространство для канваса с учётом отступов
+  // safe-area: пространство для канваса с учётом отступов
   const safeRef = useRef<HTMLDivElement>(null);
   const scale = useFitScale(safeRef, width, height);
 
@@ -42,23 +23,12 @@ export default function CanvasStage({
         className || "",
       ].join(" ")}
     >
-      {/* Тулбар прижат к верху, без скруглений */}
-      <div ref={toolbarRef} className="absolute top-0 left-0 right-0">
-        <CanvasToolbar
-          width={width}
-          height={height}
-          onCommitSize={(nw, nh) => setCanvasSize(nw, nh)}
-          onSwap={swapCanvasSize}
-          className="h-10 border-b border-[rgb(var(--cu-border))] bg-[rgb(var(--cu-grey200))]"
-        />
-      </div>
-
-      {/* SAFE-AREA: 8px от всех краёв + под тулбаром ещё его высота */}
+      {/* SAFE-AREA: 8px от всех краёв */}
       <div
         ref={safeRef}
         className="absolute"
         style={{
-          top: toolbarH + 8, // тулбар + 8px
+          top: 8,
           left: 8,
           right: 8,
           bottom: 8,

--- a/packages/studio/src/style.css
+++ b/packages/studio/src/style.css
@@ -70,6 +70,3 @@ html, body, #root {
   @apply p-2 text-sm;
 }
 
-.context-panel-topbar {
-  @apply px-2 py-1 text-neutral-400 uppercase text-xs tracking-wide flex items-center justify-between;
-}

--- a/packages/studio/src/ui/SplitContainer.tsx
+++ b/packages/studio/src/ui/SplitContainer.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+import { SplitGutter } from "./SplitGutter";
 
 export function SplitContainer({
                                children,
@@ -30,29 +31,16 @@ export function SplitContainer({
     }
   }, [sizes]);
 
-  const startDrag = (index: number) => (e: React.MouseEvent) => {
-    e.preventDefault();
-    const startX = e.clientX;
-    const startSizes = [...sizes];
+  const handleResize = (index: number, delta: number) => {
     const rect = containerRef.current?.getBoundingClientRect();
     const width = rect?.width || 1;
-
-    const onMouseMove = (ev: MouseEvent) => {
-      const delta = ev.clientX - startX;
-      const deltaPercent = (delta / width) * 100;
-      const next = [...startSizes];
-      next[index] = Math.max(5, startSizes[index] + deltaPercent);
-      next[index + 1] = Math.max(5, startSizes[index + 1] - deltaPercent);
-      setSizes(next);
-    };
-
-    const onMouseUp = () => {
-      window.removeEventListener("mousemove", onMouseMove);
-      window.removeEventListener("mouseup", onMouseUp);
-    };
-
-    window.addEventListener("mousemove", onMouseMove);
-    window.addEventListener("mouseup", onMouseUp);
+    const deltaPercent = (delta / width) * 100;
+    setSizes((prev) => {
+      const next = [...prev];
+      next[index] = Math.max(5, prev[index] + deltaPercent);
+      next[index + 1] = Math.max(5, prev[index + 1] - deltaPercent);
+      return next;
+    });
   };
 
   return (
@@ -63,10 +51,7 @@ export function SplitContainer({
             {child}
           </div>
           {i < childArray.length - 1 && (
-            <div
-              className="w-1 h-full cursor-col-resize bg-neutral-800"
-              onMouseDown={startDrag(i)}
-            />
+            <SplitGutter index={i} orientation="vertical" onResize={handleResize} />
           )}
         </React.Fragment>
       ))}

--- a/packages/studio/src/ui/SplitGutter.tsx
+++ b/packages/studio/src/ui/SplitGutter.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+type Orientation = "vertical" | "horizontal";
+
+export function SplitGutter({
+  index,
+  orientation,
+  onResize,
+}: {
+  index: number;
+  orientation: Orientation;
+  onResize: (index: number, delta: number) => void;
+}) {
+  const startDrag = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const getPos = (ev: { clientX: number; clientY: number }) =>
+      orientation === "vertical" ? ev.clientX : ev.clientY;
+    let prev = getPos(e);
+    const onMouseMove = (ev: MouseEvent) => {
+      const pos = getPos(ev);
+      const delta = pos - prev;
+      prev = pos;
+      onResize(index, delta);
+    };
+    const onMouseUp = () => {
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("mouseup", onMouseUp);
+    };
+    window.addEventListener("mousemove", onMouseMove);
+    window.addEventListener("mouseup", onMouseUp);
+  };
+
+  const className =
+    orientation === "vertical"
+      ? "w-1 h-full cursor-col-resize bg-neutral-800"
+      : "h-1 w-full cursor-row-resize bg-neutral-800";
+
+  return <div className={className} onMouseDown={startDrag} />;
+}
+
+export default SplitGutter;

--- a/packages/studio/src/ui/SplitWindow.tsx
+++ b/packages/studio/src/ui/SplitWindow.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { WindowTopBar } from "./WindowTopBar";
 
 export function SplitWindow({
                              topbar,
@@ -9,11 +10,7 @@ export function SplitWindow({
 }) {
   return (
     <div className="flex flex-col h-full">
-      {topbar && (
-        <div className="border-b border-neutral-800 px-2 py-1">
-          {topbar}
-        </div>
-      )}
+      {topbar && <WindowTopBar>{topbar}</WindowTopBar>}
       <div className="flex-1 min-h-0 overflow-hidden">
         {children}
       </div>

--- a/packages/studio/src/ui/WindowTopBar.tsx
+++ b/packages/studio/src/ui/WindowTopBar.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export function WindowTopBar({ children }: { children?: React.ReactNode }) {
+  return (
+    <div className="h-12 px-3 flex items-center justify-between bg-[rgb(var(--cu-topbar))] border-b-[1px] border-[rgb(var(--cu-border))]">
+      {children}
+    </div>
+  );
+}
+
+export default WindowTopBar;

--- a/packages/studio/src/ui/panels/ContextPanel.tsx
+++ b/packages/studio/src/ui/panels/ContextPanel.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { WindowTopBar } from "../WindowTopBar";
 
 export function ContextPanel({
   topbar,
@@ -9,7 +10,7 @@ export function ContextPanel({
 }) {
   return (
     <div className="context-panel">
-      {topbar && <div className="context-panel-topbar">{topbar}</div>}
+      {topbar && <WindowTopBar>{topbar}</WindowTopBar>}
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary
- Introduce `WindowTopBar` for consistent window headers and use it in `SplitWindow` and `ContextPanel`
- Move canvas size toolbar into the right-hand window top bar and simplify `CanvasStage`
- Extract reusable `SplitGutter` component and hook it into `SplitContainer`

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b745864c08832ab7600dfa2d4f69f5