### PR TITLE
feat: add tree collapse expand controls

### DIFF
--- a/packages/studio/src/assets/panels/AssetsPanel.tsx
+++ b/packages/studio/src/assets/panels/AssetsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react'
-import { Plus, FolderPlus, PlusSquare, MinusSquare } from 'lucide-react'
+import { Plus, FolderPlus, ChevronsUp, ChevronsDown } from 'lucide-react'
 import Tree, { type TreeItem, type DropPosition } from '../../ui/tree/Tree'
 import { useStudio } from '../../state/useStudio'
 import { ContextPanel } from '../../ui/panels/ContextPanel'
@@ -306,7 +306,7 @@ export function AssetsPanel() {
               onClick={toggleExpand}
               title={allExpanded ? 'Collapse all' : 'Expand all'}
             >
-              {allExpanded ? <MinusSquare size={14} /> : <PlusSquare size={14} />}
+              {allExpanded ? <ChevronsUp size={14} /> : <ChevronsDown size={14} />}
             </button>
             <button
               className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"

--- a/packages/studio/src/assets/panels/AssetsPanel.tsx
+++ b/packages/studio/src/assets/panels/AssetsPanel.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef, useState, useCallback } from 'react'
-import { Plus, FolderPlus, Minimize2, Maximize2 } from 'lucide-react'
+import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react'
+import { Plus, FolderPlus, PlusSquare, MinusSquare } from 'lucide-react'
 import Tree, { type TreeItem, type DropPosition } from '../../ui/tree/Tree'
 import { useStudio } from '../../state/useStudio'
 import { ContextPanel } from '../../ui/panels/ContextPanel'
@@ -181,8 +181,10 @@ export function AssetsPanel() {
     return ids
   }
 
-  const expandAll = () => setExpanded(collectIds(root))
-  const collapseAll = () => setExpanded(new Set())
+  const allIds = useMemo(() => collectIds(root), [root])
+  const allExpanded = expanded.size === allIds.size
+  const toggleExpand = () =>
+    setExpanded(allExpanded ? new Set() : new Set(allIds))
 
   // input для добавления картинок
   const fileInputRef = useRef<HTMLInputElement | null>(null)
@@ -301,17 +303,10 @@ export function AssetsPanel() {
           <div className="flex items-center gap-1">
             <button
               className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
-              onClick={collapseAll}
-              title="Collapse all"
+              onClick={toggleExpand}
+              title={allExpanded ? 'Collapse all' : 'Expand all'}
             >
-              <Minimize2 size={14} />
-            </button>
-            <button
-              className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
-              onClick={expandAll}
-              title="Expand all"
-            >
-              <Maximize2 size={14} />
+              {allExpanded ? <MinusSquare size={14} /> : <PlusSquare size={14} />}
             </button>
             <button
               className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"

--- a/packages/studio/src/assets/panels/AssetsPanel.tsx
+++ b/packages/studio/src/assets/panels/AssetsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react'
-import { Plus, FolderPlus } from 'lucide-react'
+import { Plus, FolderPlus, Minimize2, Maximize2 } from 'lucide-react'
 import Tree, { type TreeItem, type DropPosition } from '../../ui/tree/Tree'
 import { useStudio } from '../../state/useStudio'
 import { ContextPanel } from '../../ui/panels/ContextPanel'
@@ -171,6 +171,19 @@ export function AssetsPanel() {
 
   const visible = [root]
 
+  const collectIds = (it: TreeItem): Set<string> => {
+    const ids = new Set<string>()
+    const walk = (node: TreeItem) => {
+      ids.add(node.id)
+      node.children?.forEach(walk)
+    }
+    walk(it)
+    return ids
+  }
+
+  const expandAll = () => setExpanded(collectIds(root))
+  const collapseAll = () => setExpanded(new Set())
+
   // input для добавления картинок
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
@@ -286,6 +299,20 @@ export function AssetsPanel() {
         <>
           <span>Assets</span>
           <div className="flex items-center gap-1">
+            <button
+              className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+              onClick={collapseAll}
+              title="Collapse all"
+            >
+              <Minimize2 size={14} />
+            </button>
+            <button
+              className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+              onClick={expandAll}
+              title="Expand all"
+            >
+              <Maximize2 size={14} />
+            </button>
             <button
               className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
               onClick={onNewFolder}

--- a/packages/studio/src/data/panels/DataModelsPanel.tsx
+++ b/packages/studio/src/data/panels/DataModelsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Plus, Minimize2, Maximize2 } from 'lucide-react';
+import { Plus, PlusSquare, MinusSquare } from 'lucide-react';
 import Tree, { type TreeItem } from '../../ui/tree/Tree';
 import { useStudio } from '../../state/useStudio';
 import { ContextPanel } from '../../ui/panels/ContextPanel';
@@ -45,8 +45,10 @@ export function DataModelsPanel() {
     return ids;
   };
 
-  const expandAll = () => setExpanded(collectIds(root));
-  const collapseAll = () => setExpanded(new Set());
+  const allIds = useMemo(() => collectIds(root), [root]);
+  const allExpanded = expanded.size === allIds.size;
+  const toggleExpand = () =>
+    setExpanded(allExpanded ? new Set() : new Set(allIds));
 
     return (
       <ContextPanel
@@ -56,17 +58,14 @@ export function DataModelsPanel() {
             <div className="flex items-center gap-1">
               <button
                 className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
-                onClick={collapseAll}
-                title="Collapse all"
+                onClick={toggleExpand}
+                title={allExpanded ? 'Collapse all' : 'Expand all'}
               >
-                <Minimize2 size={14} />
-              </button>
-              <button
-                className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
-                onClick={expandAll}
-                title="Expand all"
-              >
-                <Maximize2 size={14} />
+                {allExpanded ? (
+                  <MinusSquare size={14} />
+                ) : (
+                  <PlusSquare size={14} />
+                )}
               </button>
               <button
                 className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"

--- a/packages/studio/src/data/panels/DataModelsPanel.tsx
+++ b/packages/studio/src/data/panels/DataModelsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Plus, ChevronsUp, ChevronsDown } from 'lucide-react';
+import { Plus, ChevronsUpDown, ChevronsDownUp } from 'lucide-react';
 import Tree, { type TreeItem } from '../../ui/tree/Tree';
 import { useStudio } from '../../state/useStudio';
 import { ContextPanel } from '../../ui/panels/ContextPanel';
@@ -62,9 +62,9 @@ export function DataModelsPanel() {
                 title={allExpanded ? 'Collapse all' : 'Expand all'}
               >
                 {allExpanded ? (
-                  <ChevronsUp size={14} />
+                  <ChevronsDownUp size={14} />
                 ) : (
-                  <ChevronsDown size={14} />
+                  <ChevronsUpDown size={14} />
                 )}
               </button>
               <button

--- a/packages/studio/src/data/panels/DataModelsPanel.tsx
+++ b/packages/studio/src/data/panels/DataModelsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Plus } from 'lucide-react';
+import { Plus, Minimize2, Maximize2 } from 'lucide-react';
 import Tree, { type TreeItem } from '../../ui/tree/Tree';
 import { useStudio } from '../../state/useStudio';
 import { ContextPanel } from '../../ui/panels/ContextPanel';
@@ -35,18 +35,47 @@ export function DataModelsPanel() {
 
   const visible = useMemo(() => [root], [root]);
 
+  const collectIds = (it: TreeItem): Set<string> => {
+    const ids = new Set<string>();
+    const walk = (node: TreeItem) => {
+      ids.add(node.id);
+      node.children?.forEach(walk);
+    };
+    walk(it);
+    return ids;
+  };
+
+  const expandAll = () => setExpanded(collectIds(root));
+  const collapseAll = () => setExpanded(new Set());
+
     return (
       <ContextPanel
         topbar={
           <>
             <span>Schemas</span>
-            <button
-              className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
-              onClick={addSchema}
-              title="Add schema"
-            >
-              <Plus size={14} />
-            </button>
+            <div className="flex items-center gap-1">
+              <button
+                className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+                onClick={collapseAll}
+                title="Collapse all"
+              >
+                <Minimize2 size={14} />
+              </button>
+              <button
+                className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+                onClick={expandAll}
+                title="Expand all"
+              >
+                <Maximize2 size={14} />
+              </button>
+              <button
+                className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+                onClick={addSchema}
+                title="Add schema"
+              >
+                <Plus size={14} />
+              </button>
+            </div>
           </>
         }
       >

--- a/packages/studio/src/data/panels/DataModelsPanel.tsx
+++ b/packages/studio/src/data/panels/DataModelsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Plus, PlusSquare, MinusSquare } from 'lucide-react';
+import { Plus, ChevronsUp, ChevronsDown } from 'lucide-react';
 import Tree, { type TreeItem } from '../../ui/tree/Tree';
 import { useStudio } from '../../state/useStudio';
 import { ContextPanel } from '../../ui/panels/ContextPanel';
@@ -62,9 +62,9 @@ export function DataModelsPanel() {
                 title={allExpanded ? 'Collapse all' : 'Expand all'}
               >
                 {allExpanded ? (
-                  <MinusSquare size={14} />
+                  <ChevronsUp size={14} />
                 ) : (
-                  <PlusSquare size={14} />
+                  <ChevronsDown size={14} />
                 )}
               </button>
               <button

--- a/packages/studio/src/layout/panels/SceneTreePanel.tsx
+++ b/packages/studio/src/layout/panels/SceneTreePanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import Tree, { type TreeItem } from "../../ui/tree/Tree";
 import { useStudio } from "../../state/useStudio";
 import { ContextPanel } from "../../ui/panels/ContextPanel";
@@ -9,8 +9,8 @@ import {
   MousePointer,
   Square,
   Type as TextIcon,
-  Minimize2,
-  Maximize2,
+  PlusSquare,
+  MinusSquare,
 } from "lucide-react";
 
 // Tags that should not appear in the scene tree.
@@ -71,12 +71,13 @@ export function SceneTreePanel() {
     return ids;
   };
 
-  const expandAll = () => {
-    if (!root) return;
-    setExpanded(collectIds(root));
-  };
-
-  const collapseAll = () => setExpanded(new Set());
+  const allIds = useMemo(
+    () => (root ? collectIds(root) : new Set<string>()),
+    [root],
+  );
+  const allExpanded = root ? expanded.size === allIds.size : false;
+  const toggleExpand = () =>
+    setExpanded(allExpanded ? new Set() : new Set(allIds));
 
   useEffect(() => {
     const dom = new DOMParser().parseFromString(
@@ -101,17 +102,14 @@ export function SceneTreePanel() {
             <div className="flex items-center gap-1">
               <button
                 className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
-                onClick={collapseAll}
-                title="Collapse all"
+                onClick={toggleExpand}
+                title={allExpanded ? "Collapse all" : "Expand all"}
               >
-                <Minimize2 size={14} />
-              </button>
-              <button
-                className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
-                onClick={expandAll}
-                title="Expand all"
-              >
-                <Maximize2 size={14} />
+                {allExpanded ? (
+                  <MinusSquare size={14} />
+                ) : (
+                  <PlusSquare size={14} />
+                )}
               </button>
             </div>
           </>
@@ -129,17 +127,14 @@ export function SceneTreePanel() {
           <div className="flex items-center gap-1">
             <button
               className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
-              onClick={collapseAll}
-              title="Collapse all"
+              onClick={toggleExpand}
+              title={allExpanded ? "Collapse all" : "Expand all"}
             >
-              <Minimize2 size={14} />
-            </button>
-            <button
-              className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
-              onClick={expandAll}
-              title="Expand all"
-            >
-              <Maximize2 size={14} />
+              {allExpanded ? (
+                <MinusSquare size={14} />
+              ) : (
+                <PlusSquare size={14} />
+              )}
             </button>
           </div>
         </>

--- a/packages/studio/src/layout/panels/SceneTreePanel.tsx
+++ b/packages/studio/src/layout/panels/SceneTreePanel.tsx
@@ -9,8 +9,8 @@ import {
   MousePointer,
   Square,
   Type as TextIcon,
-  PlusSquare,
-  MinusSquare,
+  ChevronsUp,
+  ChevronsDown,
 } from "lucide-react";
 
 // Tags that should not appear in the scene tree.
@@ -106,9 +106,9 @@ export function SceneTreePanel() {
                 title={allExpanded ? "Collapse all" : "Expand all"}
               >
                 {allExpanded ? (
-                  <MinusSquare size={14} />
+                  <ChevronsUp size={14} />
                 ) : (
-                  <PlusSquare size={14} />
+                  <ChevronsDown size={14} />
                 )}
               </button>
             </div>
@@ -131,9 +131,9 @@ export function SceneTreePanel() {
               title={allExpanded ? "Collapse all" : "Expand all"}
             >
               {allExpanded ? (
-                <MinusSquare size={14} />
+                <ChevronsUp size={14} />
               ) : (
-                <PlusSquare size={14} />
+                <ChevronsDown size={14} />
               )}
             </button>
           </div>

--- a/packages/studio/src/layout/panels/SceneTreePanel.tsx
+++ b/packages/studio/src/layout/panels/SceneTreePanel.tsx
@@ -9,6 +9,8 @@ import {
   MousePointer,
   Square,
   Type as TextIcon,
+  Minimize2,
+  Maximize2,
 } from "lucide-react";
 
 // Tags that should not appear in the scene tree.
@@ -59,6 +61,23 @@ export function SceneTreePanel() {
   const [expanded, setExpanded] = useState<Set<string>>(new Set(["0"]));
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
+  const collectIds = (it: TreeItem): Set<string> => {
+    const ids = new Set<string>();
+    const walk = (node: TreeItem) => {
+      ids.add(node.id);
+      node.children?.forEach(walk);
+    };
+    walk(it);
+    return ids;
+  };
+
+  const expandAll = () => {
+    if (!root) return;
+    setExpanded(collectIds(root));
+  };
+
+  const collapseAll = () => setExpanded(new Set());
+
   useEffect(() => {
     const dom = new DOMParser().parseFromString(
       project.layout,
@@ -75,13 +94,57 @@ export function SceneTreePanel() {
 
   if (!root)
     return (
-      <ContextPanel topbar={<span>Scene</span>}>
+      <ContextPanel
+        topbar={
+          <>
+            <span>Scene</span>
+            <div className="flex items-center gap-1">
+              <button
+                className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+                onClick={collapseAll}
+                title="Collapse all"
+              >
+                <Minimize2 size={14} />
+              </button>
+              <button
+                className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+                onClick={expandAll}
+                title="Expand all"
+              >
+                <Maximize2 size={14} />
+              </button>
+            </div>
+          </>
+        }
+      >
         <div className="px-2 py-1 text-neutral-500">Invalid layout</div>
       </ContextPanel>
     );
 
   return (
-    <ContextPanel topbar={<span>Scene</span>}>
+    <ContextPanel
+      topbar={
+        <>
+          <span>Scene</span>
+          <div className="flex items-center gap-1">
+            <button
+              className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+              onClick={collapseAll}
+              title="Collapse all"
+            >
+              <Minimize2 size={14} />
+            </button>
+            <button
+              className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+              onClick={expandAll}
+              title="Expand all"
+            >
+              <Maximize2 size={14} />
+            </button>
+          </div>
+        </>
+      }
+    >
       <Tree
         items={[root]}
         expanded={expanded}

--- a/packages/studio/src/style.css
+++ b/packages/studio/src/style.css
@@ -63,11 +63,15 @@ html, body, #root {
 }
 
 .context-panel-container {
-  @apply flex-1 overflow-auto text-sm;
+  @apply flex-1 overflow-auto text-sm min-h-0;
 }
 
 .context-panel {
-  @apply p-2 text-sm;
+  @apply flex flex-col h-full p-2 text-sm;
+}
+
+.context-panel-body {
+  @apply flex-1 overflow-auto;
 }
 
 .context-panel-topbar {

--- a/packages/studio/src/ui/panels/ContextPanel.tsx
+++ b/packages/studio/src/ui/panels/ContextPanel.tsx
@@ -10,7 +10,7 @@ export function ContextPanel({
   return (
     <div className="context-panel">
       {topbar && <div className="context-panel-topbar">{topbar}</div>}
-      {children}
+      <div className="context-panel-body">{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add collapse/expand buttons to asset tree header
- add collapse/expand buttons to scene tree header
- add collapse/expand buttons to schema tree header

## Testing
- `pnpm test` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68b748765674832ab9733f0818f0e01f