### PR TITLE
Add separate expand and collapse controls to context panels

### DIFF
--- a/packages/studio/src/assets/panels/AssetsPanel.tsx
+++ b/packages/studio/src/assets/panels/AssetsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react'
-import { Plus, FolderPlus, ChevronsUp, ChevronsDown } from 'lucide-react'
+import {Plus, FolderPlus, ChevronsDownUp, ChevronsUpDown} from 'lucide-react'
 import Tree, { type TreeItem, type DropPosition } from '../../ui/tree/Tree'
 import { useStudio } from '../../state/useStudio'
 import { ContextPanel } from '../../ui/panels/ContextPanel'
@@ -305,14 +305,14 @@ export function AssetsPanel() {
               onClick={expandAll}
               title="Expand all"
             >
-              <ChevronsDown size={14} />
+              <ChevronsUpDown size={14} />
             </button>
             <button
               className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
               onClick={collapseAll}
               title="Collapse all"
             >
-              <ChevronsUp size={14} />
+              <ChevronsDownUp size={14} />
             </button>
             <button
               className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"

--- a/packages/studio/src/assets/panels/AssetsPanel.tsx
+++ b/packages/studio/src/assets/panels/AssetsPanel.tsx
@@ -182,9 +182,8 @@ export function AssetsPanel() {
   }
 
   const allIds = useMemo(() => collectIds(root), [root])
-  const allExpanded = expanded.size === allIds.size
-  const toggleExpand = () =>
-    setExpanded(allExpanded ? new Set() : new Set(allIds))
+  const expandAll = () => setExpanded(new Set(allIds))
+  const collapseAll = () => setExpanded(new Set())
 
   // input для добавления картинок
   const fileInputRef = useRef<HTMLInputElement | null>(null)
@@ -303,10 +302,17 @@ export function AssetsPanel() {
           <div className="flex items-center gap-1">
             <button
               className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
-              onClick={toggleExpand}
-              title={allExpanded ? 'Collapse all' : 'Expand all'}
+              onClick={expandAll}
+              title="Expand all"
             >
-              {allExpanded ? <ChevronsUp size={14} /> : <ChevronsDown size={14} />}
+              <ChevronsDown size={14} />
+            </button>
+            <button
+              className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+              onClick={collapseAll}
+              title="Collapse all"
+            >
+              <ChevronsUp size={14} />
             </button>
             <button
               className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"

--- a/packages/studio/src/data/panels/DataModelsPanel.tsx
+++ b/packages/studio/src/data/panels/DataModelsPanel.tsx
@@ -46,9 +46,8 @@ export function DataModelsPanel() {
   };
 
   const allIds = useMemo(() => collectIds(root), [root]);
-  const allExpanded = expanded.size === allIds.size;
-  const toggleExpand = () =>
-    setExpanded(allExpanded ? new Set() : new Set(allIds));
+  const expandAll = () => setExpanded(new Set(allIds));
+  const collapseAll = () => setExpanded(new Set());
 
     return (
       <ContextPanel
@@ -58,14 +57,17 @@ export function DataModelsPanel() {
             <div className="flex items-center gap-1">
               <button
                 className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
-                onClick={toggleExpand}
-                title={allExpanded ? 'Collapse all' : 'Expand all'}
+                onClick={expandAll}
+                title="Expand all"
               >
-                {allExpanded ? (
-                  <ChevronsDownUp size={14} />
-                ) : (
-                  <ChevronsUpDown size={14} />
-                )}
+                <ChevronsUpDown size={14} />
+              </button>
+              <button
+                className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+                onClick={collapseAll}
+                title="Collapse all"
+              >
+                <ChevronsDownUp size={14} />
               </button>
               <button
                 className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"

--- a/packages/studio/src/layout/panels/SceneTreePanel.tsx
+++ b/packages/studio/src/layout/panels/SceneTreePanel.tsx
@@ -75,9 +75,8 @@ export function SceneTreePanel() {
     () => (root ? collectIds(root) : new Set<string>()),
     [root],
   );
-  const allExpanded = root ? expanded.size === allIds.size : false;
-  const toggleExpand = () =>
-    setExpanded(allExpanded ? new Set() : new Set(allIds));
+  const expandAll = () => setExpanded(new Set(allIds));
+  const collapseAll = () => setExpanded(new Set());
 
   useEffect(() => {
     const dom = new DOMParser().parseFromString(
@@ -102,14 +101,17 @@ export function SceneTreePanel() {
             <div className="flex items-center gap-1">
               <button
                 className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
-                onClick={toggleExpand}
-                title={allExpanded ? "Collapse all" : "Expand all"}
+                onClick={expandAll}
+                title="Expand all"
               >
-                {allExpanded ? (
-                  <ChevronsUp size={14} />
-                ) : (
-                  <ChevronsDown size={14} />
-                )}
+                <ChevronsDown size={14} />
+              </button>
+              <button
+                className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+                onClick={collapseAll}
+                title="Collapse all"
+              >
+                <ChevronsUp size={14} />
               </button>
             </div>
           </>
@@ -127,14 +129,17 @@ export function SceneTreePanel() {
           <div className="flex items-center gap-1">
             <button
               className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
-              onClick={toggleExpand}
-              title={allExpanded ? "Collapse all" : "Expand all"}
+              onClick={expandAll}
+              title="Expand all"
             >
-              {allExpanded ? (
-                <ChevronsUp size={14} />
-              ) : (
-                <ChevronsDown size={14} />
-              )}
+              <ChevronsDown size={14} />
+            </button>
+            <button
+              className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+              onClick={collapseAll}
+              title="Collapse all"
+            >
+              <ChevronsUp size={14} />
             </button>
           </div>
         </>

--- a/packages/studio/src/layout/panels/SceneTreePanel.tsx
+++ b/packages/studio/src/layout/panels/SceneTreePanel.tsx
@@ -9,8 +9,7 @@ import {
   MousePointer,
   Square,
   Type as TextIcon,
-  ChevronsUp,
-  ChevronsDown,
+  ChevronsUpDown, ChevronsDownUp,
 } from "lucide-react";
 
 // Tags that should not appear in the scene tree.
@@ -104,14 +103,14 @@ export function SceneTreePanel() {
                 onClick={expandAll}
                 title="Expand all"
               >
-                <ChevronsDown size={14} />
+                <ChevronsUpDown size={14} />
               </button>
               <button
                 className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
                 onClick={collapseAll}
                 title="Collapse all"
               >
-                <ChevronsUp size={14} />
+                <ChevronsDownUp size={14} />
               </button>
             </div>
           </>
@@ -132,14 +131,14 @@ export function SceneTreePanel() {
               onClick={expandAll}
               title="Expand all"
             >
-              <ChevronsDown size={14} />
+              <ChevronsUpDown size={14} />
             </button>
             <button
               className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
               onClick={collapseAll}
               title="Collapse all"
             >
-              <ChevronsUp size={14} />
+              <ChevronsDownUp size={14} />
             </button>
           </div>
         </>


### PR DESCRIPTION
## Summary
- split Data context panel's tree toggle into distinct expand and collapse buttons
- replicate expand/collapse buttons for Scene and Assets context panels

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7f022bd0c832aba9c70f2fb9fccd8