### PR TITLE
feat: add schema type dropdown

### DIFF
--- a/packages/studio/src/data/components/SchemaEditor.tsx
+++ b/packages/studio/src/data/components/SchemaEditor.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Plus, Trash2 } from 'lucide-react';
+import TypeDropdown from './TypeDropdown';
 import type { SchemaField } from '../types/schema.js';
 
 export default function SchemaEditor({
@@ -19,7 +20,7 @@ export default function SchemaEditor({
   };
 
   const addRow = () => {
-    onChange([...fields, { key: '', type: '', default: '' }]);
+    onChange([...fields, { key: '', type: 'Number', default: '' }]);
   };
 
   const removeRow = (idx: number) => {
@@ -47,10 +48,9 @@ export default function SchemaEditor({
               />
             </td>
             <td className="px-2 py-1">
-              <input
-                className="w-full bg-transparent outline-none"
+              <TypeDropdown
                 value={f.type}
-                onChange={(e) => handleChange(idx, 'type', e.target.value)}
+                onChange={(v) => handleChange(idx, 'type', v)}
               />
             </td>
             <td className="px-2 py-1">

--- a/packages/studio/src/data/components/TypeDropdown.tsx
+++ b/packages/studio/src/data/components/TypeDropdown.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import DropDown from "../../ui/DropDown";
+import type { DropDownOption } from "../../ui/DropDown";
+
+const baseOptions: DropDownOption[] = [
+  { value: "Number", label: "Number" },
+  { value: "String", label: "String" },
+  { value: "List", label: "List" },
+  { value: "Dictionary", label: "Dictionary" },
+];
+
+export default function TypeDropdown({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const match = /^List<(.*)>$/.exec(value);
+  const base = match ? "List" : value || "Number";
+  const inner = match ? match[1] : "Number";
+
+  const handleBaseChange = (next: string) => {
+    if (next === "List") {
+      onChange(`List<${inner}>`);
+    } else {
+      onChange(next);
+    }
+  };
+
+  const handleInnerChange = (next: string) => {
+    onChange(`List<${next}>`);
+  };
+
+  return (
+    <div className="flex items-center gap-1">
+      <DropDown value={base} options={baseOptions} onChange={handleBaseChange} />
+      {base === "List" && (
+        <TypeDropdown value={inner} onChange={handleInnerChange} />
+      )}
+    </div>
+  );
+}

--- a/packages/studio/src/data/components/TypeDropdown.tsx
+++ b/packages/studio/src/data/components/TypeDropdown.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import DropDown from "../../ui/DropDown";
 import type { DropDownOption } from "../../ui/DropDown";
+import { useStudio } from "../../state/useStudio";
 
 const baseOptions: DropDownOption[] = [
   { value: "Number", label: "Number" },
@@ -12,13 +13,24 @@ const baseOptions: DropDownOption[] = [
 export default function TypeDropdown({
   value,
   onChange,
+  allowSchemas = false,
 }: {
   value: string;
   onChange: (value: string) => void;
+  allowSchemas?: boolean;
 }) {
+  const { project } = useStudio();
+  const schemaOptions: DropDownOption[] = Object.keys(project.data ?? {}).map((n) => ({
+    value: n,
+    label: n,
+  }));
+  const options = allowSchemas
+    ? [...baseOptions, ...schemaOptions]
+    : baseOptions;
+
   const match = /^List<(.*)>$/.exec(value);
-  const base = match ? "List" : value || "Number";
-  const inner = match ? match[1] : "Number";
+  const base = match ? "List" : value || options[0]?.value;
+  const inner = match ? match[1] : schemaOptions[0]?.value || baseOptions[0].value;
 
   const handleBaseChange = (next: string) => {
     if (next === "List") {
@@ -34,9 +46,13 @@ export default function TypeDropdown({
 
   return (
     <div className="flex items-center gap-1">
-      <DropDown value={base} options={baseOptions} onChange={handleBaseChange} />
+      <DropDown value={base} options={options} onChange={handleBaseChange} />
       {base === "List" && (
-        <TypeDropdown value={inner} onChange={handleInnerChange} />
+        <TypeDropdown
+          value={inner}
+          onChange={handleInnerChange}
+          allowSchemas={true}
+        />
       )}
     </div>
   );

--- a/packages/studio/src/data/panels/DataModelsPanel.tsx
+++ b/packages/studio/src/data/panels/DataModelsPanel.tsx
@@ -7,7 +7,7 @@ import { ContextPanel } from '../../ui/panels/ContextPanel';
 function buildRoot(data: Record<string, any>): TreeItem {
   return {
     id: 'schema-root',
-    name: 'Schemas',
+    name: 'Models',
     type: 'folder',
     children: Object.keys(data).map((name) => ({
       id: `schema:${name}`,

--- a/packages/studio/src/ui/DropDown.tsx
+++ b/packages/studio/src/ui/DropDown.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+export interface DropDownOption {
+  value: string;
+  label: string;
+}
+
+export function DropDown({
+  value,
+  options,
+  onChange,
+  className = "",
+}: {
+  value: string;
+  options: DropDownOption[];
+  onChange: (value: string) => void;
+  className?: string;
+}) {
+  return (
+    <select
+      className={`bg-neutral-800 hover:bg-neutral-700 px-2 py-1 rounded outline-none ${className}`}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+export default DropDown;

--- a/packages/studio/src/ui/DropDown.tsx
+++ b/packages/studio/src/ui/DropDown.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
+import { Triangle } from "lucide-react";
 
 export interface DropDownOption {
   value: string;
@@ -16,18 +17,50 @@ export function DropDown({
   onChange: (value: string) => void;
   className?: string;
 }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const selected = options.find((o) => o.value === value);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
   return (
-    <select
-      className={`bg-neutral-800 hover:bg-neutral-700 px-2 py-1 rounded outline-none ${className}`}
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-    >
-      {options.map((o) => (
-        <option key={o.value} value={o.value}>
-          {o.label}
-        </option>
-      ))}
-    </select>
+    <div className={`relative ${className}`} ref={ref}>
+      <button
+        type="button"
+        className="flex items-center justify-between w-full bg-neutral-800 hover:bg-neutral-700 px-2 py-1 rounded"
+        onClick={() => setOpen((o) => !o)}
+      >
+        <span className="truncate">{selected?.label ?? value}</span>
+        <Triangle
+          size={10}
+          className={`ml-1 transition-transform ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+      {open && (
+        <ul className="absolute z-10 left-0 right-0 mt-1 bg-neutral-800 rounded shadow">
+          {options.map((o) => (
+            <li key={o.value}>
+              <button
+                type="button"
+                className="block w-full text-left px-2 py-1 hover:bg-neutral-700 rounded"
+                onClick={() => {
+                  onChange(o.value);
+                  setOpen(false);
+                }}
+              >
+                {o.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- add reusable `DropDown` component using existing styles
- replace schema type text input with nested `TypeDropdown`
- support selecting element types for `List` fields

## Testing
- `pnpm -F @noxigui/studio test` *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68b7f524a2b0832a9b23ef9bd7fdebf7