### PR TITLE
feat: add basic dataset editor

### DIFF
--- a/packages/studio/src/data/DataTab.tsx
+++ b/packages/studio/src/data/DataTab.tsx
@@ -2,13 +2,25 @@ import React from "react";
 import { Plus } from "lucide-react";
 import { useStudio } from "../state/useStudio";
 import SchemaEditor from "./components/SchemaEditor";
+import DatasetEditor from "./components/DatasetEditor";
 import type { SchemaField } from "./types/schema.js";
 
 export function DataTab() {
-  const { project, selectedSchema, addSchema, setSchemaFields } = useStudio();
+  const {
+    project,
+    selectedSchema,
+    selectedDataset,
+    addSchema,
+    setSchemaFields,
+    addDataset,
+    setDatasetRows,
+  } = useStudio();
   const data = project.data;
 
-  if (Object.keys(data).length === 0) {
+  if (
+    Object.keys(data.schemas).length === 0 &&
+    Object.keys(data.datasets).length === 0
+  ) {
     return (
       <div className="h-full flex items-center justify-center">
         <button
@@ -17,12 +29,21 @@ export function DataTab() {
         >
           <Plus size={14} /> Create schema
         </button>
+        <button
+          className="ml-2 inline-flex items-center gap-1 px-3 py-2 rounded bg-neutral-700 hover:bg-neutral-600"
+          onClick={() => {
+            const first = Object.keys(data.schemas)[0];
+            if (first) addDataset(first);
+          }}
+        >
+          <Plus size={14} /> Create dataset
+        </button>
       </div>
     );
   }
 
   const schema = selectedSchema
-    ? (data[selectedSchema] as SchemaField[] | undefined)
+    ? (data.schemas[selectedSchema] as SchemaField[] | undefined)
     : undefined;
   if (selectedSchema && Array.isArray(schema)) {
     return (
@@ -30,6 +51,22 @@ export function DataTab() {
         <SchemaEditor
           fields={schema}
           onChange={(f) => setSchemaFields(selectedSchema, f)}
+        />
+      </div>
+    );
+  }
+
+  const dataset = selectedDataset
+    ? project.data.datasets[selectedDataset]
+    : undefined;
+  if (selectedDataset && dataset) {
+    const schema = project.data.schemas[dataset.schemaRef] as SchemaField[];
+    return (
+      <div className="p-2 overflow-auto h-full">
+        <DatasetEditor
+          schema={schema}
+          rows={dataset.rows}
+          onChange={(rows) => setDatasetRows(selectedDataset, rows)}
         />
       </div>
     );

--- a/packages/studio/src/data/components/DatasetEditor.tsx
+++ b/packages/studio/src/data/components/DatasetEditor.tsx
@@ -1,0 +1,141 @@
+import React from 'react'
+import { Plus, Trash2 } from 'lucide-react'
+import type { SchemaField } from '../types/schema.js'
+
+export default function DatasetEditor({
+  schema,
+  rows,
+  onChange,
+}: {
+  schema: SchemaField[]
+  rows: Record<string, any>[]
+  onChange: (rows: Record<string, any>[]) => void
+}) {
+  const handleChange = (
+    rowIdx: number,
+    key: string,
+    value: any,
+  ) => {
+    const next = rows.map((r, i) => (i === rowIdx ? { ...r, [key]: value } : r))
+    onChange(next)
+  }
+
+  const addRow = () => {
+    const defaults: Record<string, any> = {}
+    for (const f of schema) {
+      if (f.default !== undefined) {
+        switch (f.type) {
+          case 'Number':
+            defaults[f.key] = Number(f.default)
+            break
+          case 'Bool':
+            defaults[f.key] = f.default === 'true'
+            break
+          default:
+            defaults[f.key] = f.default
+        }
+      } else {
+        defaults[f.key] = ''
+      }
+    }
+    onChange([
+      ...rows,
+      { id: Math.random().toString(36).slice(2, 8), ...defaults },
+    ])
+  }
+
+  const removeRow = (idx: number) => {
+    const next = rows.filter((_, i) => i !== idx)
+    onChange(next)
+  }
+
+  const renderCell = (
+    row: Record<string, any>,
+    rowIdx: number,
+    field: SchemaField,
+  ) => {
+    const value = row[field.key]
+    switch (field.type) {
+      case 'Number':
+        return (
+          <input
+            type="number"
+            className="w-full bg-transparent outline-none"
+            value={value ?? 0}
+            onChange={(e) =>
+              handleChange(rowIdx, field.key, Number(e.target.value))
+            }
+          />
+        )
+      case 'Bool':
+        return (
+          <input
+            type="checkbox"
+            checked={!!value}
+            onChange={(e) => handleChange(rowIdx, field.key, e.target.checked)}
+          />
+        )
+      default:
+        return (
+          <input
+            className="w-full bg-transparent outline-none"
+            value={value ?? ''}
+            onChange={(e) => handleChange(rowIdx, field.key, e.target.value)}
+          />
+        )
+    }
+  }
+
+  return (
+    <table className="w-full text-sm border-collapse">
+      <thead>
+        <tr className="text-left border-b border-neutral-700">
+          <th className="px-2 py-1">id</th>
+          {schema.map((f) => (
+            <th key={f.key} className="px-2 py-1">
+              {f.key}
+            </th>
+          ))}
+          <th className="px-2 py-1"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r, idx) => (
+          <tr key={idx} className="border-b border-neutral-800">
+            <td className="px-2 py-1">
+              <input
+                className="w-full bg-transparent outline-none"
+                value={r.id ?? ''}
+                onChange={(e) => handleChange(idx, 'id', e.target.value)}
+              />
+            </td>
+            {schema.map((f) => (
+              <td key={f.key} className="px-2 py-1">
+                {renderCell(r, idx, f)}
+              </td>
+            ))}
+            <td className="px-2 py-1">
+              <button
+                className="p-1 rounded hover:bg-neutral-700"
+                onClick={() => removeRow(idx)}
+                title="Delete row"
+              >
+                <Trash2 size={14} />
+              </button>
+            </td>
+          </tr>
+        ))}
+        <tr>
+          <td colSpan={schema.length + 2} className="text-center py-2">
+            <button
+              className="inline-flex items-center gap-1 px-2 py-1 rounded bg-neutral-700 hover:bg-neutral-600"
+              onClick={addRow}
+            >
+              <Plus size={14} /> Add row
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  )
+}

--- a/packages/studio/src/data/components/TypeDropdown.tsx
+++ b/packages/studio/src/data/components/TypeDropdown.tsx
@@ -20,7 +20,9 @@ export default function TypeDropdown({
   allowSchemas?: boolean;
 }) {
   const { project } = useStudio();
-  const schemaOptions: DropDownOption[] = Object.keys(project.data ?? {}).map((n) => ({
+  const schemaOptions: DropDownOption[] = Object.keys(
+    project.data.schemas ?? {},
+  ).map((n) => ({
     value: n,
     label: n,
   }));

--- a/packages/studio/src/data/panels/DataModelsPanel.tsx
+++ b/packages/studio/src/data/panels/DataModelsPanel.tsx
@@ -47,6 +47,8 @@ export function DataModelsPanel() {
     setSelectedSchema,
     selectedDataset,
     setSelectedDataset,
+    renameSchema,
+    renameDataset,
   } = useStudio();
   const [root, setRoot] = useState<TreeItem>(() =>
     buildRoot(project.data ?? { schemas: {}, datasets: {} })
@@ -79,6 +81,13 @@ export function DataModelsPanel() {
   const allIds = useMemo(() => collectIds(root), [root]);
   const expandAll = () => setExpanded(new Set(allIds));
   const collapseAll = () => setExpanded(new Set());
+
+  const handleRename = (id: string, nextName: string) => {
+    if (id.startsWith('schema:'))
+      renameSchema(id.slice('schema:'.length), nextName);
+    else if (id.startsWith('dataset:'))
+      renameDataset(id.slice('dataset:'.length), nextName);
+  };
 
     return (
       <ContextPanel
@@ -144,6 +153,7 @@ export function DataModelsPanel() {
               setSelectedDataset(null);
             }
           }}
+          onRename={handleRename}
         />
       </ContextPanel>
     );

--- a/packages/studio/src/data/panels/DataModelsPanel.tsx
+++ b/packages/studio/src/data/panels/DataModelsPanel.tsx
@@ -48,12 +48,14 @@ export function DataModelsPanel() {
     selectedDataset,
     setSelectedDataset,
   } = useStudio();
-  const [root, setRoot] = useState<TreeItem>(() => buildRoot(project.data));
+  const [root, setRoot] = useState<TreeItem>(() =>
+    buildRoot(project.data ?? { schemas: {}, datasets: {} })
+  );
   const [expanded, setExpanded] = useState<Set<string>>(new Set(['schema-root', 'dataset-root']));
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
   useEffect(() => {
-    setRoot(buildRoot(project.data));
+    setRoot(buildRoot(project.data ?? { schemas: {}, datasets: {} }));
   }, [project.data]);
 
   useEffect(() => {

--- a/packages/studio/src/data/store.ts
+++ b/packages/studio/src/data/store.ts
@@ -1,11 +1,16 @@
 import type { StateCreator } from 'zustand';
 import type { SchemaField } from './types/schema.js';
+import type { Dataset } from './types/dataset.js';
 
 export type DataSlice = {
   selectedSchema: string | null;
+  selectedDataset: string | null;
   setSelectedSchema: (name: string | null) => void;
+  setSelectedDataset: (name: string | null) => void;
   addSchema: () => void;
   setSchemaFields: (name: string, fields: SchemaField[]) => void;
+  addDataset: (schemaRef: string) => void;
+  setDatasetRows: (name: string, rows: Dataset['rows']) => void;
   setData: (o: any) => void;
 };
 
@@ -13,15 +18,20 @@ export const createDataSlice = (
   scheduleSave: () => void
 ): StateCreator<any, [], [], DataSlice> => (set, _get) => ({
   selectedSchema: null,
-  setSelectedSchema: (name) => set({ selectedSchema: name }),
+  selectedDataset: null,
+  setSelectedSchema: (name) => set({ selectedSchema: name, selectedDataset: null }),
+  setSelectedDataset: (name) => set({ selectedDataset: name, selectedSchema: null }),
   addSchema: () => {
     set((s: any) => {
-      const existing = new Set(Object.keys(s.project.data ?? {}));
+      const existing = new Set(Object.keys(s.project.data.schemas ?? {}));
       const base = 'New schema';
       let name = base;
       let i = 2;
       while (existing.has(name)) name = `${base} ${i++}`;
-      const data = { ...s.project.data, [name]: [] as SchemaField[] };
+      const data = {
+        ...s.project.data,
+        schemas: { ...s.project.data.schemas, [name]: [] as SchemaField[] },
+      };
       return {
         project: { ...s.project, data },
         selectedSchema: name,
@@ -34,7 +44,45 @@ export const createDataSlice = (
     set((s: any) => ({
       project: {
         ...s.project,
-        data: { ...s.project.data, [name]: fields },
+        data: {
+          ...s.project.data,
+          schemas: { ...s.project.data.schemas, [name]: fields },
+        },
+      },
+      dirty: { ...s.dirty, data: true },
+    }));
+    scheduleSave();
+  },
+  addDataset: (schemaRef) => {
+    set((s: any) => {
+      const existing = new Set(Object.keys(s.project.data.datasets ?? {}));
+      const base = 'New dataset';
+      let name = base;
+      let i = 2;
+      while (existing.has(name)) name = `${base} ${i++}`;
+      const data = {
+        ...s.project.data,
+        datasets: {
+          ...s.project.data.datasets,
+          [name]: { schemaRef, rows: [] as Dataset['rows'] },
+        },
+      };
+      return {
+        project: { ...s.project, data },
+        selectedDataset: name,
+        dirty: { ...s.dirty, data: true },
+      };
+    });
+    scheduleSave();
+  },
+  setDatasetRows: (name, rows) => {
+    set((s: any) => ({
+      project: {
+        ...s.project,
+        data: {
+          ...s.project.data,
+          datasets: { ...s.project.data.datasets, [name]: { ...s.project.data.datasets[name], rows } },
+        },
       },
       dirty: { ...s.dirty, data: true },
     }));

--- a/packages/studio/src/data/types/dataset.ts
+++ b/packages/studio/src/data/types/dataset.ts
@@ -1,0 +1,4 @@
+export type Dataset = {
+  schemaRef: string;
+  rows: Record<string, any>[];
+};

--- a/packages/studio/src/layout/components/Renderer.tsx
+++ b/packages/studio/src/layout/components/Renderer.tsx
@@ -128,7 +128,7 @@ export function Renderer() {
       try {
         const gui = Noxi.gui.create(project.layout);
         guiRef.current = gui;
-        (gui as any).viewModel = project.data;
+        (gui as any).viewModel = project.data.datasets;
 
         app.stage.addChild(gui.container.getDisplayObject());
         gui.layout({ width: app.renderer.width, height: app.renderer.height });

--- a/packages/studio/src/state/useStudio.ts
+++ b/packages/studio/src/state/useStudio.ts
@@ -119,8 +119,9 @@ export const useStudio = create<StudioState>()((set, get, store) => {
       try {
         const loaded = await loadProjectFromIDB();
         if (loaded) {
+          const parsed = ProjectZ.parse(loaded);
           set({
-            project: loaded,
+            project: parsed,
             activeTab: 'Layout',
             dirty: { layout: false, data: false, assets: false },
             canvas: { ...defaultCanvas },

--- a/packages/studio/src/state/useStudio.ts
+++ b/packages/studio/src/state/useStudio.ts
@@ -22,7 +22,7 @@ export const defaultProject: Project = {
   name: 'Untitled',
   version: '0.1',
   layout: '<Grid/>',
-  data: {},
+  data: { schemas: {}, datasets: {} },
   assets: [],
   screen: { width: 1280, height: 720 },
   meta: {

--- a/packages/studio/src/types/project.ts
+++ b/packages/studio/src/types/project.ts
@@ -17,7 +17,31 @@ export const ProjectZ = z.object({
   name: z.string(),
   version: z.string().default("0.1"),
   layout: z.string(),
-  data: z.record(z.string(), z.any()).default({}),
+  data: z
+    .object({
+      schemas: z
+        .record(
+          z.string(),
+          z.array(
+            z.object({
+              key: z.string(),
+              type: z.string(),
+              default: z.string().optional(),
+            }),
+          ),
+        )
+        .default({}),
+      datasets: z
+        .record(
+          z.string(),
+          z.object({
+            schemaRef: z.string(),
+            rows: z.array(z.record(z.string(), z.any())).default([]),
+          }),
+        )
+        .default({}),
+    })
+    .default({ schemas: {}, datasets: {} }),
   assets: z.array(AssetZ).default([]),
   meta: z
     .object({


### PR DESCRIPTION
## Summary
- support datasets in project schema and store
- add dataset tree nodes and editor for basic row editing
- expose datasets to runtime view model

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7fce864dc832aad64a4d1851dd1b5