### PR TITLE
feat(studio): improve data panel

### DIFF
--- a/packages/studio/src/data/DataTab.tsx
+++ b/packages/studio/src/data/DataTab.tsx
@@ -5,10 +5,14 @@ import SchemaEditor from "./components/SchemaEditor";
 import type { SchemaField } from "./types/schema.js";
 
 export function DataTab() {
-  const { project, selectedSchema, addSchema, setSchemaFields } = useStudio();
-  const data = project.data;
+  const { project, selectedSchema, selectedDataset, addSchema, setSchemaFields } =
+    useStudio();
+  const schemas = project.data.schemas;
 
-  if (Object.keys(data).length === 0) {
+  if (
+    Object.keys(schemas).length === 0 &&
+    Object.keys(project.data.datasets ?? {}).length === 0
+  ) {
     return (
       <div className="h-full flex items-center justify-center">
         <button
@@ -22,7 +26,7 @@ export function DataTab() {
   }
 
   const schema = selectedSchema
-    ? (data[selectedSchema] as SchemaField[] | undefined)
+    ? (schemas[selectedSchema] as SchemaField[] | undefined)
     : undefined;
   if (selectedSchema && Array.isArray(schema)) {
     return (
@@ -31,6 +35,13 @@ export function DataTab() {
           fields={schema}
           onChange={(f) => setSchemaFields(selectedSchema, f)}
         />
+      </div>
+    );
+  }
+  if (selectedDataset) {
+    return (
+      <div className="h-full flex items-center justify-center text-neutral-400">
+        Dataset editor not implemented
       </div>
     );
   }

--- a/packages/studio/src/data/components/TypeDropdown.tsx
+++ b/packages/studio/src/data/components/TypeDropdown.tsx
@@ -20,7 +20,9 @@ export default function TypeDropdown({
   allowSchemas?: boolean;
 }) {
   const { project } = useStudio();
-  const schemaOptions: DropDownOption[] = Object.keys(project.data ?? {}).map((n) => ({
+  const schemaOptions: DropDownOption[] = Object.keys(
+    project.data.schemas ?? {}
+  ).map((n) => ({
     value: n,
     label: n,
   }));

--- a/packages/studio/src/data/panels/DataModelsPanel.tsx
+++ b/packages/studio/src/data/panels/DataModelsPanel.tsx
@@ -4,101 +4,169 @@ import Tree, { type TreeItem } from '../../ui/tree/Tree';
 import { useStudio } from '../../state/useStudio';
 import { ContextPanel } from '../../ui/panels/ContextPanel';
 
-function buildRoot(data: Record<string, any>): TreeItem {
-  return {
-    id: 'schema-root',
-    name: 'Models',
-    type: 'folder',
-    children: Object.keys(data).map((name) => ({
-      id: `schema:${name}`,
-      name,
-      type: 'schema',
-      children: [],
-    })),
-  };
+function buildRoots(data: { schemas: Record<string, any>; datasets: Record<string, any> }): TreeItem[] {
+  return [
+    {
+      id: 'schemas-root',
+      name: 'Schemas',
+      type: 'folder',
+      children: Object.keys(data.schemas ?? {}).map((name) => ({
+        id: `schema:${name}`,
+        name,
+        type: 'schema',
+        children: [],
+      })),
+    },
+    {
+      id: 'datasets-root',
+      name: 'DataSet',
+      type: 'folder',
+      children: Object.keys(data.datasets ?? {}).map((name) => ({
+        id: `dataset:${name}`,
+        name,
+        type: 'dataset',
+        children: [],
+      })),
+    },
+  ];
 }
 
 export function DataModelsPanel() {
-  const { project, addSchema, selectedSchema, setSelectedSchema } = useStudio();
-  const [root, setRoot] = useState<TreeItem>(() => buildRoot(project.data));
-  const [expanded, setExpanded] = useState<Set<string>>(new Set(['schema-root']));
+  const {
+    project,
+    addSchema,
+    addDataset,
+    selectedSchema,
+    selectedDataset,
+    setSelectedSchema,
+    setSelectedDataset,
+    renameSchema,
+    renameDataset,
+    deleteSchema,
+    deleteDataset,
+  } = useStudio();
+  const [roots, setRoots] = useState<TreeItem[]>(() => buildRoots(project.data));
+  const [expanded, setExpanded] = useState<Set<string>>(
+    new Set(['schemas-root', 'datasets-root'])
+  );
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
   useEffect(() => {
-    setRoot(buildRoot(project.data));
+    setRoots(buildRoots(project.data));
   }, [project.data]);
 
   useEffect(() => {
     if (selectedSchema) setSelected(new Set([`schema:${selectedSchema}`]));
+    else if (selectedDataset) setSelected(new Set([`dataset:${selectedDataset}`]));
     else setSelected(new Set());
-  }, [selectedSchema]);
+  }, [selectedSchema, selectedDataset]);
 
-  const visible = useMemo(() => [root], [root]);
+  const visible = useMemo(() => roots, [roots]);
 
-  const collectIds = (it: TreeItem): Set<string> => {
+  const collectIds = (arr: TreeItem[]): Set<string> => {
     const ids = new Set<string>();
     const walk = (node: TreeItem) => {
       ids.add(node.id);
       node.children?.forEach(walk);
     };
-    walk(it);
+    arr.forEach(walk);
     return ids;
   };
 
-  const allIds = useMemo(() => collectIds(root), [root]);
+  const allIds = useMemo(() => collectIds(roots), [roots]);
   const expandAll = () => setExpanded(new Set(allIds));
   const collapseAll = () => setExpanded(new Set());
 
-    return (
-      <ContextPanel
-        topbar={
-          <>
-            <span>Data</span>
-            <div className="flex items-center gap-1">
+  return (
+    <ContextPanel
+      topbar={
+        <>
+          <span>Data</span>
+          <div className="flex items-center gap-1">
+            <button
+              className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+              onClick={expandAll}
+              title="Expand all"
+            >
+              <ChevronsUpDown size={14} />
+            </button>
+            <button
+              className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+              onClick={collapseAll}
+              title="Collapse all"
+            >
+              <ChevronsDownUp size={14} />
+            </button>
+          </div>
+        </>
+      }
+    >
+      <Tree
+        items={visible}
+        expanded={expanded}
+        selected={selected}
+        onToggle={(id) =>
+          setExpanded((prev) => {
+            const next = new Set(prev);
+            next.has(id) ? next.delete(id) : next.add(id);
+            return next;
+          })
+        }
+        onSelect={(next) => {
+          setSelected(next);
+          const first = Array.from(next)[0];
+          if (first && first.startsWith('schema:')) {
+            setSelectedSchema(first.slice('schema:'.length));
+            setSelectedDataset(null);
+          } else if (first && first.startsWith('dataset:')) {
+            setSelectedDataset(first.slice('dataset:'.length));
+            setSelectedSchema(null);
+          } else {
+            setSelectedSchema(null);
+            setSelectedDataset(null);
+          }
+        }}
+        onRename={(id, nextName) => {
+          if (id.startsWith('schema:'))
+            renameSchema(id.slice('schema:'.length), nextName);
+          else if (id.startsWith('dataset:'))
+            renameDataset(id.slice('dataset:'.length), nextName);
+        }}
+        onDelete={(id) => {
+          if (id.startsWith('schema:')) deleteSchema(id.slice('schema:'.length));
+          else if (id.startsWith('dataset:'))
+            deleteDataset(id.slice('dataset:'.length));
+        }}
+        renderActions={(item) => {
+          if (item.id === 'schemas-root')
+            return (
               <button
                 className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
-                onClick={expandAll}
-                title="Expand all"
-              >
-                <ChevronsUpDown size={14} />
-              </button>
-              <button
-                className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
-                onClick={collapseAll}
-                title="Collapse all"
-              >
-                <ChevronsDownUp size={14} />
-              </button>
-              <button
-                className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
-                onClick={addSchema}
                 title="Add schema"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  addSchema();
+                }}
               >
                 <Plus size={14} />
               </button>
-            </div>
-          </>
-        }
-      >
-        <Tree
-          items={visible}
-          expanded={expanded}
-          selected={selected}
-          onToggle={(id) =>
-            setExpanded((prev) => {
-              const next = new Set(prev);
-              next.has(id) ? next.delete(id) : next.add(id);
-              return next;
-            })
-          }
-          onSelect={(next) => {
-            setSelected(next);
-            const first = Array.from(next)[0];
-            if (first && first.startsWith('schema:'))
-              setSelectedSchema(first.slice('schema:'.length));
-            else setSelectedSchema(null);
-          }}
-        />
-      </ContextPanel>
-    );
-  }
+            );
+          if (item.id === 'datasets-root')
+            return (
+              <button
+                className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+                title="Add dataset"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  addDataset();
+                }}
+              >
+                <Plus size={14} />
+              </button>
+            );
+          return undefined;
+        }}
+      />
+    </ContextPanel>
+  );
+}

--- a/packages/studio/src/data/store.ts
+++ b/packages/studio/src/data/store.ts
@@ -1,50 +1,158 @@
 import type { StateCreator } from 'zustand';
 import type { SchemaField } from './types/schema.js';
+import type { Project } from '../types/project.js';
 
 export type DataSlice = {
   selectedSchema: string | null;
+  selectedDataset: string | null;
   setSelectedSchema: (name: string | null) => void;
+  setSelectedDataset: (name: string | null) => void;
   addSchema: () => void;
+  addDataset: () => void;
+  renameSchema: (oldName: string, nextName: string) => void;
+  renameDataset: (oldName: string, nextName: string) => void;
+  deleteSchema: (name: string) => void;
+  deleteDataset: (name: string) => void;
   setSchemaFields: (name: string, fields: SchemaField[]) => void;
-  setData: (o: any) => void;
+  setDatasetValue: (name: string, value: any) => void;
+  setData: (o: Project['data']) => void;
 };
 
 export const createDataSlice = (
-  scheduleSave: () => void
-): StateCreator<any, [], [], DataSlice> => (set, _get) => ({
+  runProjectCommand: (
+    mutate: (p: Project) => Project,
+    sideEffects?: { onExecute?: () => void; onUndo?: () => void }
+  ) => void,
+): StateCreator<any, [], [], DataSlice> => (set, get) => ({
   selectedSchema: null,
-  setSelectedSchema: (name) => set({ selectedSchema: name }),
+  selectedDataset: null,
+  setSelectedSchema: (name) => set({ selectedSchema: name, selectedDataset: null }),
+  setSelectedDataset: (name) => set({ selectedDataset: name, selectedSchema: null }),
+
   addSchema: () => {
-    set((s: any) => {
-      const existing = new Set(Object.keys(s.project.data ?? {}));
-      const base = 'New schema';
-      let name = base;
-      let i = 2;
-      while (existing.has(name)) name = `${base} ${i++}`;
-      const data = { ...s.project.data, [name]: [] as SchemaField[] };
-      return {
-        project: { ...s.project, data },
-        selectedSchema: name,
-        dirty: { ...s.dirty, data: true },
-      };
-    });
-    scheduleSave();
-  },
-  setSchemaFields: (name, fields) => {
-    set((s: any) => ({
-      project: {
-        ...s.project,
-        data: { ...s.project.data, [name]: fields },
+    const existing = new Set(Object.keys(get().project.data.schemas ?? {}));
+    const base = 'New schema';
+    let name = base;
+    let i = 2;
+    while (existing.has(name)) name = `${base} ${i++}`;
+
+    runProjectCommand(
+      (p) => {
+        const schemas = { ...(p.data.schemas ?? {}), [name]: [] as SchemaField[] };
+        return { ...p, data: { ...p.data, schemas } };
       },
-      dirty: { ...s.dirty, data: true },
-    }));
-    scheduleSave();
+      {
+        onExecute: () => set({ selectedSchema: name }),
+        onUndo: () => set({ selectedSchema: null }),
+      },
+    );
   },
-  setData: (data) => {
-    set((s: any) => ({
-      project: { ...s.project, data },
-      dirty: { ...s.dirty, data: true },
-    }));
-    scheduleSave();
+
+  addDataset: () => {
+    const existing = new Set(Object.keys(get().project.data.datasets ?? {}));
+    const base = 'New dataset';
+    let name = base;
+    let i = 2;
+    while (existing.has(name)) name = `${base} ${i++}`;
+
+    runProjectCommand(
+      (p) => {
+        const datasets = { ...(p.data.datasets ?? {}), [name]: [] };
+        return { ...p, data: { ...p.data, datasets } };
+      },
+      {
+        onExecute: () => set({ selectedDataset: name }),
+        onUndo: () => set({ selectedDataset: null }),
+      },
+    );
   },
+
+  renameSchema: (oldName, nextName) => {
+    const trimmed = nextName.trim();
+    if (!trimmed || trimmed === oldName) return;
+    runProjectCommand(
+      (p) => {
+        const schemas = { ...(p.data.schemas ?? {}) };
+        schemas[trimmed] = schemas[oldName];
+        delete schemas[oldName];
+        return { ...p, data: { ...p.data, schemas } };
+      },
+      {
+        onExecute: () => {
+          if (get().selectedSchema === oldName) set({ selectedSchema: trimmed });
+        },
+        onUndo: () => {
+          if (get().selectedSchema === trimmed) set({ selectedSchema: oldName });
+        },
+      },
+    );
+  },
+
+  renameDataset: (oldName, nextName) => {
+    const trimmed = nextName.trim();
+    if (!trimmed || trimmed === oldName) return;
+    runProjectCommand(
+      (p) => {
+        const datasets = { ...(p.data.datasets ?? {}) };
+        datasets[trimmed] = datasets[oldName];
+        delete datasets[oldName];
+        return { ...p, data: { ...p.data, datasets } };
+      },
+      {
+        onExecute: () => {
+          if (get().selectedDataset === oldName)
+            set({ selectedDataset: trimmed });
+        },
+        onUndo: () => {
+          if (get().selectedDataset === trimmed)
+            set({ selectedDataset: oldName });
+        },
+      },
+    );
+  },
+
+  deleteSchema: (name) =>
+    runProjectCommand(
+      (p) => {
+        const schemas = { ...(p.data.schemas ?? {}) };
+        delete schemas[name];
+        return { ...p, data: { ...p.data, schemas } };
+      },
+      {
+        onExecute: () => {
+          if (get().selectedSchema === name) set({ selectedSchema: null });
+        },
+        onUndo: () => set({ selectedSchema: name }),
+      },
+    ),
+
+  deleteDataset: (name) =>
+    runProjectCommand(
+      (p) => {
+        const datasets = { ...(p.data.datasets ?? {}) };
+        delete datasets[name];
+        return { ...p, data: { ...p.data, datasets } };
+      },
+      {
+        onExecute: () => {
+          if (get().selectedDataset === name) set({ selectedDataset: null });
+        },
+        onUndo: () => set({ selectedDataset: name }),
+      },
+    ),
+
+  setSchemaFields: (name, fields) =>
+    runProjectCommand((p) => {
+      const schemas = { ...(p.data.schemas ?? {}), [name]: fields };
+      return { ...p, data: { ...p.data, schemas } };
+    }),
+
+  setDatasetValue: (name, value) =>
+    runProjectCommand((p) => {
+      const datasets = { ...(p.data.datasets ?? {}), [name]: value };
+      return { ...p, data: { ...p.data, datasets } };
+    }),
+
+  setData: (data) => runProjectCommand((p) => ({ ...p, data })),
 });
+

--- a/packages/studio/src/types/project.ts
+++ b/packages/studio/src/types/project.ts
@@ -17,13 +17,18 @@ export const ProjectZ = z.object({
   name: z.string(),
   version: z.string().default("0.1"),
   layout: z.string(),
-  data: z.record(z.string(), z.any()).default({}),
+  data: z
+    .object({
+      schemas: z.record(z.string(), z.any()).default({}),
+      datasets: z.record(z.string(), z.any()).default({}),
+    })
+    .default({ schemas: {}, datasets: {} }),
   assets: z.array(AssetZ).default([]),
   meta: z
     .object({
       theme: z.string().optional(),
-      assetFolders: z.array(z.string()).default([]),                // список папок (корневых и/или вложенных, формат "Textures/Monsters")
-      assetPaths: z.record(z.string(), z.string()).default({}),     // alias -> "Textures/Monsters" ; пустая строка или отсутствие => корень
+      assetFolders: z.array(z.string()).default([]), // список папок (корневых и/или вложенных, формат "Textures/Monsters")
+      assetPaths: z.record(z.string(), z.string()).default({}), // alias -> "Textures/Monsters" ; пустая строка или отсутствие => корень
     })
     .default({ assetFolders: [], assetPaths: {} }),
   screen: ScreenZ.default({ width: 1280, height: 720 }),

--- a/packages/studio/src/ui/tree/Tree.tsx
+++ b/packages/studio/src/ui/tree/Tree.tsx
@@ -81,6 +81,9 @@ export type TreeProps = {
 
   /** Кастомная политика dnd. По умолчанию: inside только в папку. */
   allowDrop?: (source: TreeItem, target: TreeItem, pos: DropPosition) => boolean
+
+  /** Кастомный рендер кнопок действий. Если возвращает undefined — используются дефолтные */
+  renderActions?: (item: TreeItem) => React.ReactNode | undefined
 }
 
 /** Собираем карту id -> item для быстрых проверок */
@@ -105,6 +108,7 @@ export default function Tree({
   renderIcon,
   renderLabel,
   allowDrop,
+  renderActions,
 }: TreeProps) {
   const itemsMap = useMemo(() => collectMap(items), [items])
 
@@ -178,6 +182,7 @@ export default function Tree({
           onDelete={onDelete}
           renderIcon={renderIcon}
           renderLabel={renderLabel}
+          renderActions={renderActions}
           itemsMap={itemsMap}
           canDrop={canDrop}
           draggingIdsRef={draggingIdsRef}
@@ -200,6 +205,7 @@ function TreeNode({
   onDelete,
   renderIcon,
   renderLabel,
+  renderActions,
   itemsMap,
   canDrop,
   draggingIdsRef,
@@ -218,6 +224,7 @@ function TreeNode({
   onDelete?: (id: string) => void
   renderIcon?: (item: TreeItem, expanded: boolean) => React.ReactNode
   renderLabel?: (item: TreeItem) => React.ReactNode
+  renderActions?: (item: TreeItem) => React.ReactNode | undefined
   itemsMap: Map<string, TreeItem>
   canDrop: (source: TreeItem, target: TreeItem, pos: DropPosition) => boolean
   draggingIdsRef: React.MutableRefObject<string[] | null>
@@ -398,29 +405,40 @@ function TreeNode({
         )}
 
         {/* Кнопки действий */}
-        <div className="ml-auto flex items-center gap-1 opacity-0 group-hover:opacity-100">
-          <button
-            className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
-            title="Rename"
-            onClick={(e) => {
-              e.stopPropagation()
-              setEditing(true)
-              setDraft(item.name)
-            }}
-          >
-            <Edit2 size={14} />
-          </button>
-          <button
-            className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
-            title="Delete"
-            onClick={(e) => {
-              e.stopPropagation()
-              onDelete?.(item.id)
-            }}
-          >
-            <Trash2 size={14} />
-          </button>
-        </div>
+        {(() => {
+          const actions = renderActions?.(item)
+          if (actions !== undefined)
+            return (
+              <div className="ml-auto flex items-center gap-1 opacity-0 group-hover:opacity-100">
+                {actions}
+              </div>
+            )
+          return (
+            <div className="ml-auto flex items-center gap-1 opacity-0 group-hover:opacity-100">
+              <button
+                className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+                title="Rename"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setEditing(true)
+                  setDraft(item.name)
+                }}
+              >
+                <Edit2 size={14} />
+              </button>
+              <button
+                className="p-1 rounded hover:bg-neutral-700 text-neutral-300 hover:text-white"
+                title="Delete"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onDelete?.(item.id)
+                }}
+              >
+                <Trash2 size={14} />
+              </button>
+            </div>
+          )
+        })()}
       </div>
 
       {dropHint === 'before' && (
@@ -446,6 +464,7 @@ function TreeNode({
               onDelete={onDelete}
               renderIcon={renderIcon}
               renderLabel={renderLabel}
+              renderActions={renderActions}
               itemsMap={itemsMap}
               canDrop={canDrop}
               draggingIdsRef={draggingIdsRef}


### PR DESCRIPTION
## Summary
- restructure project data to separate schemas and datasets
- add add/rename/delete with undo support for schemas and datasets
- add custom tree actions and new Data panel UI

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8062eacc0832aa1855f15e6ff173b