### PR TITLE
feat(studio): highlight selected grid

### DIFF
--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -16,6 +16,7 @@
     "lucide-react": "^0.542.0",
     "monaco-editor": "^0.52.2",
     "noxi.js": "workspace:*",
+    "@noxigui/runtime": "workspace:*",
     "pixi.js": "^7.4.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/packages/studio/src/layout/components/Renderer.tsx
+++ b/packages/studio/src/layout/components/Renderer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from "react";
 import * as PIXI from "pixi.js";
 import Noxi from "noxi.js";
+import { Grid } from "@noxigui/runtime";
 import { useStudio } from "../../state/useStudio";
 import type { Project } from "../../types/project";
 import CanvasStage from "./CanvasStage";
@@ -154,8 +155,77 @@ export function Renderer() {
   return (
     <div className="w-full h-full relative">
       <CanvasStage>
-        <div ref={mountRef} className="w-full h-full" />
+        <>
+          <div ref={mountRef} className="w-full h-full" />
+          <SelectionOverlay guiRef={guiRef} />
+        </>
       </CanvasStage>
+    </div>
+  );
+}
+
+function SelectionOverlay({
+  guiRef,
+}: {
+  guiRef: React.MutableRefObject<ReturnType<typeof Noxi.gui.create> | null>;
+}) {
+  useStudio((s) => s.project); // subscribe to project changes
+  const layoutSelection = useStudio((s) => s.layoutSelection);
+  if (!layoutSelection || layoutSelection.tag.toLowerCase() !== "grid") return null;
+  const gui = guiRef.current;
+  if (!gui) return null;
+
+  const getKids = (el: any): any[] => {
+    const kids: any[] = [];
+    if (Array.isArray(el.children)) kids.push(...el.children);
+    const child = (el as any).child;
+    if (child) kids.push(child);
+    return kids;
+  };
+
+  const parts = layoutSelection.id.split(".").slice(1);
+  let el: any = gui.root;
+  let x = el.final?.x ?? 0;
+  let y = el.final?.y ?? 0;
+  for (const p of parts) {
+    const idx = Number(p);
+    const kids = getKids(el);
+    el = kids[idx];
+    if (!el) return null;
+    x += el.final?.x ?? 0;
+    y += el.final?.y ?? 0;
+  }
+  if (!(el instanceof Grid)) return null;
+
+  const color = "#3da5ff";
+  const w = el.final.width;
+  const h = el.final.height;
+
+  return (
+    <div
+      className="absolute pointer-events-none"
+      style={{
+        left: x,
+        top: y,
+        width: w,
+        height: h,
+        border: `2px solid ${color}`,
+        boxSizing: "border-box",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          background: color,
+          color: "#fff",
+          fontSize: 10,
+          padding: "1px 4px",
+        }}
+      >
+        {layoutSelection.name}
+      </div>
     </div>
   );
 }

--- a/packages/studio/src/layout/panels/SceneTreePanel.tsx
+++ b/packages/studio/src/layout/panels/SceneTreePanel.tsx
@@ -54,8 +54,18 @@ function findByPath(el: Element, path: string): Element | null {
   return curr ?? null;
 }
 
+function findItemById(root: TreeItem, id: string): TreeItem | null {
+  if (root.id === id) return root;
+  if (!root.children) return null;
+  for (const ch of root.children) {
+    const found = findItemById(ch, id);
+    if (found) return found;
+  }
+  return null;
+}
+
 export function SceneTreePanel() {
-  const { project, setLayout } = useStudio();
+  const { project, setLayout, setLayoutSelection } = useStudio();
   const [root, setRoot] = useState<TreeItem | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set(["0"]));
   const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -164,7 +174,20 @@ export function SceneTreePanel() {
             return next;
           })
         }
-        onSelect={setSelected}
+        onSelect={(sel) => {
+          setSelected(sel);
+          const first = sel.values().next().value as string | undefined;
+          if (!first) {
+            setLayoutSelection(null);
+          } else {
+            const item = root ? findItemById(root, first) : null;
+            if (item) {
+              setLayoutSelection({ id: first, tag: item.tag ?? '', name: item.name });
+            } else {
+              setLayoutSelection(null);
+            }
+          }
+        }}
         onRename={(id, nextName) => {
           const dom = new DOMParser().parseFromString(
             project.layout,

--- a/packages/studio/src/layout/store.ts
+++ b/packages/studio/src/layout/store.ts
@@ -2,6 +2,10 @@ import type { StateCreator } from 'zustand';
 
 export type LayoutSlice = {
   canvas: { width: number; height: number };
+  layoutSelection: { id: string; tag: string; name: string } | null;
+  setLayoutSelection: (
+    sel: { id: string; tag: string; name: string } | null
+  ) => void;
   setLayout: (layout: string) => void;
   setCanvasSize: (w: number, h: number) => void;
   swapCanvasSize: () => void;
@@ -13,6 +17,8 @@ export const createLayoutSlice = (
   scheduleSave: () => void
 ): StateCreator<any, [], [], LayoutSlice> => (set, _get) => ({
   canvas: { ...defaultCanvas },
+  layoutSelection: null,
+  setLayoutSelection: (sel) => set({ layoutSelection: sel }),
   setLayout: (layout) => {
     set((s: any) => ({
       project: { ...s.project, layout },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
 
   packages/studio:
     dependencies:
+      '@noxigui/runtime':
+        specifier: workspace:*
+        version: link:../runtime
       fast-json-patch:
         specifier: ^3.1.1
         version: 3.1.1


### PR DESCRIPTION
## Summary
- track selection in scene tree
- show blue overlay with grid name for selected grid
- add runtime dependency

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e56ad994832a8505d93e3c60e060