### PR TITLE
Fix selection overlay positioning

### DIFF
--- a/packages/studio/src/layout/components/Renderer.tsx
+++ b/packages/studio/src/layout/components/Renderer.tsx
@@ -191,7 +191,7 @@ function SelectionOverlay({
       <div
         style={{
           position: "absolute",
-          top: -2,
+          top: 0,
           left: 0,
           transform: "translateY(-100%)",
           background: color,

--- a/packages/studio/src/layout/components/Renderer.tsx
+++ b/packages/studio/src/layout/components/Renderer.tsx
@@ -169,7 +169,7 @@ function SelectionOverlay({
 }: {
   guiRef: React.MutableRefObject<ReturnType<typeof Noxi.gui.create> | null>;
 }) {
-  useStudio((s) => s.project); // subscribe to project changes
+  const project = useStudio((s) => s.project); // subscribe to project changes
   const layoutSelection = useStudio((s) => s.layoutSelection);
   if (!layoutSelection || layoutSelection.tag.toLowerCase() !== "grid") return null;
   const gui = guiRef.current;
@@ -213,8 +213,15 @@ function SelectionOverlay({
   if (!(el instanceof Grid)) return null;
 
   const color = "#3da5ff";
+  const size =
+    parts.length === 0
+      ? {
+          width: project.screen?.width ?? el.final.width,
+          height: project.screen?.height ?? el.final.height,
+        }
+      : { width: el.final.width, height: el.final.height };
   const topLeft = pt(m, 0, 0);
-  const bottomRight = pt(m, el.final.width, el.final.height);
+  const bottomRight = pt(m, size.width, size.height);
   const x = topLeft.x;
   const y = topLeft.y;
   const w = bottomRight.x - topLeft.x;

--- a/packages/studio/src/layout/components/Renderer.tsx
+++ b/packages/studio/src/layout/components/Renderer.tsx
@@ -4,7 +4,7 @@ import Noxi from "noxi.js";
 import { useStudio } from "../../state/useStudio";
 import type { Project } from "../../types/project";
 import CanvasStage from "./CanvasStage";
-import { getGridOverlayBounds } from "../utils/getGridOverlayBounds";
+import { getGridOverlayBounds } from "../utils/getGridOverlayBounds.js";
 
 export function Renderer() {
   const { project } = useStudio();

--- a/packages/studio/src/layout/components/Renderer.tsx
+++ b/packages/studio/src/layout/components/Renderer.tsx
@@ -185,19 +185,17 @@ function SelectionOverlay({
 
   const parts = layoutSelection.id.split(".").slice(1);
   let el: any = gui.root;
-  let x = el.final?.x ?? 0;
-  let y = el.final?.y ?? 0;
   for (const p of parts) {
     const idx = Number(p);
     const kids = getKids(el);
     el = kids[idx];
     if (!el) return null;
-    x += el.final?.x ?? 0;
-    y += el.final?.y ?? 0;
   }
   if (!(el instanceof Grid)) return null;
 
   const color = "#3da5ff";
+  const x = el.final?.x ?? 0;
+  const y = el.final?.y ?? 0;
   const w = el.final.width;
   const h = el.final.height;
 
@@ -216,8 +214,9 @@ function SelectionOverlay({
       <div
         style={{
           position: "absolute",
-          top: 0,
+          top: -2,
           left: 0,
+          transform: "translateY(-100%)",
           background: color,
           color: "#fff",
           fontSize: 10,

--- a/packages/studio/src/layout/utils/getGridOverlayBounds.ts
+++ b/packages/studio/src/layout/utils/getGridOverlayBounds.ts
@@ -35,6 +35,7 @@ export function getGridOverlayBounds(
   let el: any = gui.root;
   const rootFinal = el.final ?? { x: 0, y: 0 };
   const rootMargin = el.margin ?? { l: 0, t: 0 };
+  const rootPad = (el as any).padding ?? { l: 0, t: 0 };
   const rootHx = (el as any).horizontalOffset ?? 0;
   const rootVy = (el as any).verticalOffset ?? 0;
   let m: Mat = [
@@ -42,8 +43,8 @@ export function getGridOverlayBounds(
     0,
     0,
     1,
-    rootFinal.x - rootMargin.l - rootHx,
-    rootFinal.y - rootMargin.t - rootVy,
+    rootFinal.x + rootPad.l - rootMargin.l - rootHx,
+    rootFinal.y + rootPad.t - rootMargin.t - rootVy,
   ];
   for (const p of parts) {
     const idx = Number(p);
@@ -53,7 +54,8 @@ export function getGridOverlayBounds(
     const final = child.final ?? { x: 0, y: 0 };
     const hx = (el as any).horizontalOffset ?? 0;
     const vy = (el as any).verticalOffset ?? 0;
-    const local: Mat = [1, 0, 0, 1, final.x - hx, final.y - vy];
+    const pad = (el as any).padding ?? { l: 0, t: 0 };
+    const local: Mat = [1, 0, 0, 1, final.x + pad.l - hx, final.y + pad.t - vy];
     m = mul(m, local);
     el = child;
   }

--- a/packages/studio/src/layout/utils/getGridOverlayBounds.ts
+++ b/packages/studio/src/layout/utils/getGridOverlayBounds.ts
@@ -37,12 +37,22 @@ export function getGridOverlayBounds(
   for (const p of parts) {
     const idx = Number(p);
     const kids = getKids(el);
-    el = kids[idx];
-    if (!el) return null;
-    const final = el.final ?? { x: 0, y: 0 };
-    const margin = el.margin ?? { l: 0, t: 0 };
-    const local: Mat = [1, 0, 0, 1, final.x - margin.l, final.y - margin.t];
+    const child = kids[idx];
+    if (!child) return null;
+    const parentMargin = el.margin ?? { l: 0, t: 0 };
+    const parentPadding = (el as any).padding ?? { l: 0, t: 0 };
+    const final = child.final ?? { x: 0, y: 0 };
+    const margin = child.margin ?? { l: 0, t: 0 };
+    const local: Mat = [
+      1,
+      0,
+      0,
+      1,
+      parentMargin.l + parentPadding.l + final.x - margin.l,
+      parentMargin.t + parentPadding.t + final.y - margin.t,
+    ];
     m = mul(m, local);
+    el = child;
   }
   if (!(el instanceof Grid)) return null;
   const margin = el.margin ?? { l: 0, t: 0, r: 0, b: 0 };

--- a/packages/studio/src/layout/utils/getGridOverlayBounds.ts
+++ b/packages/studio/src/layout/utils/getGridOverlayBounds.ts
@@ -21,6 +21,8 @@ const getKids = (el: any): any[] => {
   if (Array.isArray(el.children)) kids.push(...el.children);
   const child = (el as any).child;
   if (child) kids.push(child);
+  const content = (el as any).content;
+  if (content) kids.push(content);
   return kids;
 };
 
@@ -39,18 +41,9 @@ export function getGridOverlayBounds(
     const kids = getKids(el);
     const child = kids[idx];
     if (!child) return null;
-    const parentMargin = el.margin ?? { l: 0, t: 0 };
-    const parentPadding = (el as any).padding ?? { l: 0, t: 0 };
     const final = child.final ?? { x: 0, y: 0 };
     const margin = child.margin ?? { l: 0, t: 0 };
-    const local: Mat = [
-      1,
-      0,
-      0,
-      1,
-      parentMargin.l + parentPadding.l + final.x - margin.l,
-      parentMargin.t + parentPadding.t + final.y - margin.t,
-    ];
+    const local: Mat = [1, 0, 0, 1, final.x - margin.l, final.y - margin.t];
     m = mul(m, local);
     el = child;
   }

--- a/packages/studio/src/layout/utils/getGridOverlayBounds.ts
+++ b/packages/studio/src/layout/utils/getGridOverlayBounds.ts
@@ -33,19 +33,10 @@ export function getGridOverlayBounds(
   if (!gui || !layoutSelection || layoutSelection.tag.toLowerCase() !== "grid") return null;
   const parts = layoutSelection.id.split(".").slice(1);
   let el: any = gui.root;
-  const rootFinal = el.final ?? { x: 0, y: 0 };
-  const rootMargin = el.margin ?? { l: 0, t: 0 };
   const rootPad = (el as any).padding ?? { l: 0, t: 0 };
   const rootHx = (el as any).horizontalOffset ?? 0;
   const rootVy = (el as any).verticalOffset ?? 0;
-  let m: Mat = [
-    1,
-    0,
-    0,
-    1,
-    rootFinal.x + rootPad.l - rootMargin.l - rootHx,
-    rootFinal.y + rootPad.t - rootMargin.t - rootVy,
-  ];
+  let m: Mat = [1, 0, 0, 1, rootPad.l - rootHx, rootPad.t - rootVy];
   for (const p of parts) {
     const idx = Number(p);
     const kids = getKids(el);

--- a/packages/studio/src/layout/utils/getGridOverlayBounds.ts
+++ b/packages/studio/src/layout/utils/getGridOverlayBounds.ts
@@ -31,18 +31,25 @@ export function getGridOverlayBounds(
   if (!gui || !layoutSelection || layoutSelection.tag.toLowerCase() !== "grid") return null;
   const parts = layoutSelection.id.split(".").slice(1);
   let el: any = gui.root;
-  let m: Mat = [1, 0, 0, 1, el.final?.x ?? 0, el.final?.y ?? 0];
+  const rootFinal = el.final ?? { x: 0, y: 0 };
+  const rootMargin = el.margin ?? { l: 0, t: 0 };
+  let m: Mat = [1, 0, 0, 1, rootFinal.x - rootMargin.l, rootFinal.y - rootMargin.t];
   for (const p of parts) {
     const idx = Number(p);
     const kids = getKids(el);
     el = kids[idx];
     if (!el) return null;
-    const local: Mat = [1, 0, 0, 1, el.final?.x ?? 0, el.final?.y ?? 0];
+    const final = el.final ?? { x: 0, y: 0 };
+    const margin = el.margin ?? { l: 0, t: 0 };
+    const local: Mat = [1, 0, 0, 1, final.x - margin.l, final.y - margin.t];
     m = mul(m, local);
   }
   if (!(el instanceof Grid)) return null;
+  const margin = el.margin ?? { l: 0, t: 0, r: 0, b: 0 };
+  const width = el.final.width + margin.l + margin.r;
+  const height = el.final.height + margin.t + margin.b;
   const topLeft = pt(m, 0, 0);
-  const bottomRight = pt(m, el.final.width, el.final.height);
+  const bottomRight = pt(m, width, height);
   return {
     x: topLeft.x,
     y: topLeft.y,

--- a/packages/studio/src/layout/utils/getGridOverlayBounds.ts
+++ b/packages/studio/src/layout/utils/getGridOverlayBounds.ts
@@ -35,7 +35,16 @@ export function getGridOverlayBounds(
   let el: any = gui.root;
   const rootFinal = el.final ?? { x: 0, y: 0 };
   const rootMargin = el.margin ?? { l: 0, t: 0 };
-  let m: Mat = [1, 0, 0, 1, rootFinal.x - rootMargin.l, rootFinal.y - rootMargin.t];
+  const rootHx = (el as any).horizontalOffset ?? 0;
+  const rootVy = (el as any).verticalOffset ?? 0;
+  let m: Mat = [
+    1,
+    0,
+    0,
+    1,
+    rootFinal.x - rootMargin.l - rootHx,
+    rootFinal.y - rootMargin.t - rootVy,
+  ];
   for (const p of parts) {
     const idx = Number(p);
     const kids = getKids(el);
@@ -43,7 +52,9 @@ export function getGridOverlayBounds(
     if (!child) return null;
     const final = child.final ?? { x: 0, y: 0 };
     const margin = child.margin ?? { l: 0, t: 0 };
-    const local: Mat = [1, 0, 0, 1, final.x - margin.l, final.y - margin.t];
+    const hx = (el as any).horizontalOffset ?? 0;
+    const vy = (el as any).verticalOffset ?? 0;
+    const local: Mat = [1, 0, 0, 1, final.x - margin.l - hx, final.y - margin.t - vy];
     m = mul(m, local);
     el = child;
   }

--- a/packages/studio/src/layout/utils/getGridOverlayBounds.ts
+++ b/packages/studio/src/layout/utils/getGridOverlayBounds.ts
@@ -51,19 +51,20 @@ export function getGridOverlayBounds(
     const child = kids[idx];
     if (!child) return null;
     const final = child.final ?? { x: 0, y: 0 };
-    const margin = child.margin ?? { l: 0, t: 0 };
     const hx = (el as any).horizontalOffset ?? 0;
     const vy = (el as any).verticalOffset ?? 0;
-    const local: Mat = [1, 0, 0, 1, final.x - margin.l - hx, final.y - margin.t - vy];
+    const local: Mat = [1, 0, 0, 1, final.x - hx, final.y - vy];
     m = mul(m, local);
     el = child;
   }
   if (!(el instanceof Grid)) return null;
   const margin = el.margin ?? { l: 0, t: 0, r: 0, b: 0 };
-  const width = el.final.width + margin.l + margin.r;
-  const height = el.final.height + margin.t + margin.b;
-  const topLeft = pt(m, 0, 0);
-  const bottomRight = pt(m, width, height);
+  const topLeft = parts.length === 0 ? { x: m[4], y: m[5] } : pt(m, -margin.l, -margin.t);
+  const bottomRight = pt(
+    m,
+    el.final.width + (parts.length === 0 ? margin.l + margin.r : margin.r),
+    el.final.height + (parts.length === 0 ? margin.t + margin.b : margin.b),
+  );
   return {
     x: topLeft.x,
     y: topLeft.y,

--- a/packages/studio/src/layout/utils/getGridOverlayBounds.ts
+++ b/packages/studio/src/layout/utils/getGridOverlayBounds.ts
@@ -1,0 +1,52 @@
+import { Grid } from "@noxigui/runtime";
+
+export type LayoutSelection = { id: string; tag: string; name: string };
+
+type Mat = [number, number, number, number, number, number];
+const mul = (m1: Mat, m2: Mat): Mat => [
+  m1[0] * m2[0] + m1[2] * m2[1],
+  m1[1] * m2[0] + m1[3] * m2[1],
+  m1[0] * m2[2] + m1[2] * m2[3],
+  m1[1] * m2[2] + m1[3] * m2[3],
+  m1[0] * m2[4] + m1[2] * m2[5] + m1[4],
+  m1[1] * m2[4] + m1[3] * m2[5] + m1[5],
+];
+const pt = (m: Mat, x: number, y: number) => ({
+  x: m[0] * x + m[2] * y + m[4],
+  y: m[1] * x + m[3] * y + m[5],
+});
+
+const getKids = (el: any): any[] => {
+  const kids: any[] = [];
+  if (Array.isArray(el.children)) kids.push(...el.children);
+  const child = (el as any).child;
+  if (child) kids.push(child);
+  return kids;
+};
+
+export function getGridOverlayBounds(
+  gui: { root: any } | null,
+  layoutSelection: LayoutSelection | null,
+): { x: number; y: number; width: number; height: number } | null {
+  if (!gui || !layoutSelection || layoutSelection.tag.toLowerCase() !== "grid") return null;
+  const parts = layoutSelection.id.split(".").slice(1);
+  let el: any = gui.root;
+  let m: Mat = [1, 0, 0, 1, el.final?.x ?? 0, el.final?.y ?? 0];
+  for (const p of parts) {
+    const idx = Number(p);
+    const kids = getKids(el);
+    el = kids[idx];
+    if (!el) return null;
+    const local: Mat = [1, 0, 0, 1, el.final?.x ?? 0, el.final?.y ?? 0];
+    m = mul(m, local);
+  }
+  if (!(el instanceof Grid)) return null;
+  const topLeft = pt(m, 0, 0);
+  const bottomRight = pt(m, el.final.width, el.final.height);
+  return {
+    x: topLeft.x,
+    y: topLeft.y,
+    width: bottomRight.x - topLeft.x,
+    height: bottomRight.y - topLeft.y,
+  };
+}

--- a/packages/studio/tests/grid-overlay.test.ts
+++ b/packages/studio/tests/grid-overlay.test.ts
@@ -13,15 +13,17 @@ const renderer = {
   createContainer() { return {} as any; },
 } as any;
 
-test('overlay bounds match grid finals for root and child', () => {
+test('overlay bounds include margins along element path', () => {
   const root = new Grid(renderer);
-  root.final = { x: 0, y: 0, width: 200, height: 100 } as any;
+  root.margin = { l: 10, t: 20, r: 10, b: 20 } as any;
+  root.final = { x: 10, y: 20, width: 180, height: 160 } as any;
   const child = new Grid(renderer);
+  child.margin = { l: 3, t: 4, r: 5, b: 6 } as any;
   child.final = { x: 30, y: 40, width: 50, height: 60 } as any;
   root.add(child);
   const gui = { root } as any;
   const rootSel: LayoutSelection = { id: '0', tag: 'grid', name: 'root' };
   const childSel: LayoutSelection = { id: '0.0', tag: 'grid', name: 'child' };
-  assert.deepEqual(getGridOverlayBounds(gui, rootSel), { x: 0, y: 0, width: 200, height: 100 });
-  assert.deepEqual(getGridOverlayBounds(gui, childSel), { x: 30, y: 40, width: 50, height: 60 });
+  assert.deepEqual(getGridOverlayBounds(gui, rootSel), { x: 0, y: 0, width: 200, height: 200 });
+  assert.deepEqual(getGridOverlayBounds(gui, childSel), { x: 27, y: 36, width: 58, height: 70 });
 });

--- a/packages/studio/tests/grid-overlay.test.ts
+++ b/packages/studio/tests/grid-overlay.test.ts
@@ -51,9 +51,34 @@ test('overlay bounds include margins and paddings along element path', () => {
     height: 200,
   });
   assert.deepEqual(getGridOverlayBounds(gui, childSel), {
-    x: 92,
-    y: 122,
+    x: 70,
+    y: 88,
     width: 78,
     height: 90,
+  });
+});
+
+test('overlay aligns with grid inside padded border', () => {
+  const root = new Grid(renderer);
+  root.final = { x: 0, y: 0, width: 200, height: 150 } as any;
+
+  const border = new BorderPanel(renderer);
+  border.padding = { l: 12, t: 12, r: 0, b: 0 } as any;
+  border.final = { x: 0, y: 0, width: 100, height: 80 } as any;
+
+  const child = new Grid(renderer);
+  child.final = { x: 12, y: 12, width: 50, height: 40 } as any;
+
+  border.child = child;
+  root.add(border);
+  const gui = { root } as any;
+
+  const sel: LayoutSelection = { id: '0.0.0', tag: 'grid', name: 'child' };
+
+  assert.deepEqual(getGridOverlayBounds(gui, sel), {
+    x: 12,
+    y: 12,
+    width: 50,
+    height: 40,
   });
 });

--- a/packages/studio/tests/grid-overlay.test.ts
+++ b/packages/studio/tests/grid-overlay.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Grid } from '@noxigui/runtime';
+import { Grid, BorderPanel } from '@noxigui/runtime';
 import { getGridOverlayBounds, LayoutSelection } from '../src/layout/utils/getGridOverlayBounds.js';
 
 const graphicsObj: any = { visible: false, clear() {}, lineStyle() {}, drawRect() {}, beginFill() {}, endFill() {}, moveTo() {}, lineTo() {} };
@@ -10,20 +10,50 @@ const renderer = {
   createImage() { return {} as any; },
   createText() { return {} as any; },
   createGraphics() { return gfx; },
-  createContainer() { return {} as any; },
+  createContainer() {
+    return {
+      addChild() {},
+      removeChild() {},
+      destroy() {},
+      setMask() {},
+      setPosition() {},
+      setSortableChildren() {},
+      getDisplayObject() { return {}; },
+    } as any;
+  },
 } as any;
 
-test('overlay bounds include margins along element path', () => {
+test('overlay bounds include margins and paddings along element path', () => {
   const root = new Grid(renderer);
   root.margin = { l: 10, t: 20, r: 10, b: 20 } as any;
   root.final = { x: 10, y: 20, width: 180, height: 160 } as any;
+
+  const panel = new BorderPanel(renderer);
+  panel.margin = { l: 7, t: 8, r: 9, b: 10 } as any;
+  panel.padding = { l: 5, t: 6, r: 7, b: 8 } as any;
+  panel.final = { x: 30, y: 40, width: 120, height: 100 } as any;
+
   const child = new Grid(renderer);
   child.margin = { l: 3, t: 4, r: 5, b: 6 } as any;
-  child.final = { x: 30, y: 40, width: 50, height: 60 } as any;
-  root.add(child);
+  child.final = { x: 50, y: 60, width: 70, height: 80 } as any;
+
+  panel.child = child;
+  root.add(panel);
   const gui = { root } as any;
+
   const rootSel: LayoutSelection = { id: '0', tag: 'grid', name: 'root' };
-  const childSel: LayoutSelection = { id: '0.0', tag: 'grid', name: 'child' };
-  assert.deepEqual(getGridOverlayBounds(gui, rootSel), { x: 0, y: 0, width: 200, height: 200 });
-  assert.deepEqual(getGridOverlayBounds(gui, childSel), { x: 27, y: 36, width: 58, height: 70 });
+  const childSel: LayoutSelection = { id: '0.0.0', tag: 'grid', name: 'child' };
+
+  assert.deepEqual(getGridOverlayBounds(gui, rootSel), {
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 200,
+  });
+  assert.deepEqual(getGridOverlayBounds(gui, childSel), {
+    x: 92,
+    y: 122,
+    width: 78,
+    height: 90,
+  });
 });

--- a/packages/studio/tests/grid-overlay.test.ts
+++ b/packages/studio/tests/grid-overlay.test.ts
@@ -53,8 +53,8 @@ test('overlay bounds include margins and paddings along element path', () => {
     height: 200,
   });
   assert.deepEqual(getGridOverlayBounds(gui, childSel), {
-    x: 35,
-    y: 46,
+    x: 40,
+    y: 52,
     width: 78,
     height: 90,
   });
@@ -69,7 +69,7 @@ test('overlay aligns with grid inside padded border', () => {
   border.final = { x: 0, y: 0, width: 100, height: 80 } as any;
 
   const child = new Grid(renderer);
-  child.final = { x: 12, y: 12, width: 50, height: 40 } as any;
+  child.final = { x: 0, y: 0, width: 50, height: 40 } as any;
 
   border.child = child;
   root.add(border);

--- a/packages/studio/tests/grid-overlay.test.ts
+++ b/packages/studio/tests/grid-overlay.test.ts
@@ -85,6 +85,26 @@ test('overlay aligns with grid inside padded border', () => {
   });
 });
 
+test('root final offsets do not affect child overlays', () => {
+  const root = new Grid(renderer);
+  root.final = { x: 26, y: 94, width: 600, height: 400 } as any;
+
+  const child = new Grid(renderer);
+  child.final = { x: 10, y: 345, width: 100, height: 50 } as any;
+
+  root.add(child);
+  const gui = { root } as any;
+
+  const sel: LayoutSelection = { id: '0.0', tag: 'grid', name: 'child' };
+
+  assert.deepEqual(getGridOverlayBounds(gui, sel), {
+    x: 10,
+    y: 345,
+    width: 100,
+    height: 50,
+  });
+});
+
 test('overlay accounts for ScrollViewer scroll offsets', () => {
   const root = new Grid(renderer);
   root.final = { x: 0, y: 0, width: 200, height: 200 } as any;

--- a/packages/studio/tests/grid-overlay.test.ts
+++ b/packages/studio/tests/grid-overlay.test.ts
@@ -37,7 +37,7 @@ test('overlay bounds include margins and paddings along element path', () => {
 
   const child = new Grid(renderer);
   child.margin = { l: 3, t: 4, r: 5, b: 6 } as any;
-  child.final = { x: 50, y: 60, width: 70, height: 80 } as any;
+  child.final = { x: 8, y: 10, width: 70, height: 80 } as any;
 
   panel.child = child;
   root.add(panel);
@@ -53,8 +53,8 @@ test('overlay bounds include margins and paddings along element path', () => {
     height: 200,
   });
   assert.deepEqual(getGridOverlayBounds(gui, childSel), {
-    x: 70,
-    y: 88,
+    x: 35,
+    y: 46,
     width: 78,
     height: 90,
   });

--- a/packages/studio/tests/grid-overlay.test.ts
+++ b/packages/studio/tests/grid-overlay.test.ts
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Grid } from '@noxigui/runtime';
+import { getGridOverlayBounds, LayoutSelection } from '../src/layout/utils/getGridOverlayBounds.js';
+
+const graphicsObj: any = { visible: false, clear() {}, lineStyle() {}, drawRect() {}, beginFill() {}, endFill() {}, moveTo() {}, lineTo() {} };
+const gfx = { clear() {}, beginFill() { return this; }, drawRect() { return this; }, endFill() {}, destroy() {}, getDisplayObject() { return graphicsObj; } } as any;
+const renderer = {
+  getTexture() { return undefined; },
+  createImage() { return {} as any; },
+  createText() { return {} as any; },
+  createGraphics() { return gfx; },
+  createContainer() { return {} as any; },
+} as any;
+
+test('overlay bounds match grid finals for root and child', () => {
+  const root = new Grid(renderer);
+  root.final = { x: 0, y: 0, width: 200, height: 100 } as any;
+  const child = new Grid(renderer);
+  child.final = { x: 30, y: 40, width: 50, height: 60 } as any;
+  root.add(child);
+  const gui = { root } as any;
+  const rootSel: LayoutSelection = { id: '0', tag: 'grid', name: 'root' };
+  const childSel: LayoutSelection = { id: '0.0', tag: 'grid', name: 'child' };
+  assert.deepEqual(getGridOverlayBounds(gui, rootSel), { x: 0, y: 0, width: 200, height: 100 });
+  assert.deepEqual(getGridOverlayBounds(gui, childSel), { x: 30, y: 40, width: 50, height: 60 });
+});

--- a/packages/studio/tests/grid-overlay.test.ts
+++ b/packages/studio/tests/grid-overlay.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { Grid, BorderPanel } from '@noxigui/runtime';
+import { Grid, BorderPanel, ScrollViewer } from '@noxigui/runtime';
 import { getGridOverlayBounds, LayoutSelection } from '../src/layout/utils/getGridOverlayBounds.js';
 
 const graphicsObj: any = { visible: false, clear() {}, lineStyle() {}, drawRect() {}, beginFill() {}, endFill() {}, moveTo() {}, lineTo() {} };
@@ -18,7 +18,9 @@ const renderer = {
       setMask() {},
       setPosition() {},
       setSortableChildren() {},
-      getDisplayObject() { return {}; },
+      addEventListener() {},
+      setEventMode() {},
+      getDisplayObject() { return { addEventListener() {} }; },
     } as any;
   },
 } as any;
@@ -80,5 +82,30 @@ test('overlay aligns with grid inside padded border', () => {
     y: 12,
     width: 50,
     height: 40,
+  });
+});
+
+test('overlay accounts for ScrollViewer scroll offsets', () => {
+  const root = new Grid(renderer);
+  root.final = { x: 0, y: 0, width: 200, height: 200 } as any;
+
+  const viewer = new ScrollViewer(renderer);
+  viewer.final = { x: 0, y: 0, width: 100, height: 100 } as any;
+  (viewer as any)._vy = 30;
+
+  const child = new Grid(renderer);
+  child.final = { x: 0, y: 30, width: 80, height: 60 } as any;
+
+  viewer.setContent(child);
+  root.add(viewer);
+
+  const gui = { root } as any;
+  const sel: LayoutSelection = { id: '0.0.0', tag: 'grid', name: 'child' };
+
+  assert.deepEqual(getGridOverlayBounds(gui, sel), {
+    x: 0,
+    y: 0,
+    width: 80,
+    height: 60,
   });
 });

--- a/packages/studio/tests/grid-overlay.test.ts
+++ b/packages/studio/tests/grid-overlay.test.ts
@@ -53,8 +53,8 @@ test('overlay bounds include margins and paddings along element path', () => {
     height: 200,
   });
   assert.deepEqual(getGridOverlayBounds(gui, childSel), {
-    x: 40,
-    y: 52,
+    x: 35,
+    y: 46,
     width: 78,
     height: 90,
   });
@@ -69,7 +69,7 @@ test('overlay aligns with grid inside padded border', () => {
   border.final = { x: 0, y: 0, width: 100, height: 80 } as any;
 
   const child = new Grid(renderer);
-  child.final = { x: 0, y: 0, width: 50, height: 40 } as any;
+  child.final = { x: 12, y: 12, width: 50, height: 40 } as any;
 
   border.child = child;
   root.add(border);
@@ -114,7 +114,7 @@ test('overlay accounts for ScrollViewer scroll offsets', () => {
   (viewer as any)._vy = 30;
 
   const child = new Grid(renderer);
-  child.final = { x: 0, y: 30, width: 80, height: 60 } as any;
+  child.final = { x: 0, y: -30, width: 80, height: 60 } as any;
 
   viewer.setContent(child);
   root.add(viewer);

--- a/packages/studio/tsconfig.test.json
+++ b/packages/studio/tsconfig.test.json
@@ -10,5 +10,10 @@
     "moduleResolution": "node",
     "verbatimModuleSyntax": false
   },
-  "include": ["tests", "src/state/**/*", "src/types/**/*"]
+  "include": [
+    "tests",
+    "src/layout/**/*",
+    "src/state/**/*",
+    "src/types/**/*"
+  ]
 }


### PR DESCRIPTION
## Summary
- position grid selection overlay using absolute coordinates
- place grid name label above overlay frame

## Testing
- `pnpm test` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68b9eadeb768832a98beb1bd9192ed9a